### PR TITLE
Use codecov for test coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,6 @@ on:
       - main
       - cleanup
   pull_request:
-    branches:
-      - main
-      - cleanup
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,13 +26,15 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade pytest
           python -m pip install flake8 pytest pytest-cov coveralls
+          python -m pip install codecov
           pip install -r requirements.txt
           pip install -r test_requirements.txt
           python -m pip install .
 
       - name: Test with pytest
         run: |
-          pytest --cov=sim-pipeline
+          pytest --cov=./ --cov-report=xml
+          codecov
 #      - name: Coveralls
 #        env:
 #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,3 +44,5 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -36,8 +36,12 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --cov=sim-pipeline
-      - name: Coveralls
+#      - name: Coveralls
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        run: |
+#          coveralls --service=github
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          coveralls --service=github
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/*

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 sim-pipeline
 ============
 
-|Read the Docs| |GitHub| |Coveralls|
+|Read the Docs| |GitHub| |Codecov|
 
 
 LSST strong lensing simulation pipeline.
@@ -50,6 +50,8 @@ See our Citation_ guidelines.
 
 .. |GitHub| image:: https://github.com/LSST-strong-lensing/sim-pipeline/workflows/CI/badge.svg
     :target: https://github.com/LSST-strong-lensing/sim-pipeline/actions
+    :alt: Build Status
 
-.. |Coveralls| image:: https://coveralls.io/repos/github/LSST-strong-lensing/sim-pipeline/badge.svg
-    :target: https://coveralls.io/github/LSST-strong-lensing/sim-pipeline
+.. |Codecov| image:: https://codecov.io/gh/LSST-strong-lensing/sim-pipeline/graph/badge.svg?token=PyDRdtsGSX
+    :target: https://codecov.io/gh/LSST-strong-lensing/sim-pipeline
+    :alt: Code coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
-comment: false
-github_checks:
-    annotations: false
+comment:                  # this is a top-level key
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: false        # [true :: must have a base report to post]
+  require_head: true       # [true :: must have a head report to post]


### PR DESCRIPTION
This PR adds `codecov` as the test coverage reporting system instead of `coveralls` and intends to fix the coverage reporting issue and close #43. 