### PR TITLE
Add autoformatting of code using black and docformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: ruff
         exclude: docs/.*
-        args: ["--line-length=120"]
+        args: ["--line-length=88"]
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.7.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,15 @@
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
@@ -11,3 +23,23 @@ repos:
     hooks:
       - id: nbqa-ruff
         args: ["--line-length=120"]
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black-jupyter
+        language_version: python3
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.5
+    hooks:
+      - id: docformatter
+        additional_dependencies: [tomli]
+        args: [-r, --black, --in-place]

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 sim-pipeline
 ============
 
-|Read the Docs| |GitHub| |Codecov|
+|Read the Docs| |GitHub| |Codecov| |Black|
 
 
 LSST strong lensing simulation pipeline.
@@ -55,3 +55,6 @@ See our Citation_ guidelines.
 .. |Codecov| image:: https://codecov.io/gh/LSST-strong-lensing/sim-pipeline/graph/badge.svg?token=PyDRdtsGSX
     :target: https://codecov.io/gh/LSST-strong-lensing/sim-pipeline
     :alt: Code coverage
+
+.. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/psf/black

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 sim-pipeline
 ============
 
-|Read the Docs| |GitHub| |Codecov| |Black|
+|Read the Docs| |GitHub| |Codecov| |Black| |docformatter| |docstyle|
 
 
 LSST strong lensing simulation pipeline.
@@ -58,3 +58,9 @@ See our Citation_ guidelines.
 
 .. |Black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
+
+.. |docstyle| image:: https://img.shields.io/badge/%20style-sphinx-0a507a.svg
+    :target: https://www.sphinx-doc.org/en/master/usage/index.html
+
+.. |docformatter| image:: https://img.shields.io/badge/%20formatter-docformatter-fedcba.svg
+    :target: https://github.com/PyCQA/docformatter

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,8 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.insert(0, os.path.abspath(".."))
 
 import sim_pipeline
 
@@ -31,22 +32,22 @@ import sim_pipeline
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'sim-pipeline'
+project = "sim-pipeline"
 copyright = "2022, DESC & SLSC"
 author = "DESC & SLSC"
 
@@ -69,10 +70,10 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -83,7 +84,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the
@@ -94,13 +95,13 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ---------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'sim_pipelinedoc'
+htmlhelp_basename = "sim_pipelinedoc"
 
 
 # -- Options for LaTeX output ------------------------------------------
@@ -109,15 +110,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -127,9 +125,13 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'sim_pipeline.tex',
-     'sim-pipeline Documentation',
-     'DESC & SLSC', 'manual'),
+    (
+        master_doc,
+        "sim_pipeline.tex",
+        "sim-pipeline Documentation",
+        "DESC & SLSC",
+        "manual",
+    ),
 ]
 
 
@@ -137,11 +139,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'sim_pipeline',
-     'sim-pipeline Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "sim_pipeline", "sim-pipeline Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -150,13 +148,13 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'sim_pipeline',
-     'sim-pipeline Documentation',
-     author,
-     'sim_pipeline',
-     'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "sim_pipeline",
+        "sim-pipeline Documentation",
+        author,
+        "sim_pipeline",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
-
-
-

--- a/notebooks/galaxy_galaxy_lensing_tutorial.ipynb
+++ b/notebooks/galaxy_galaxy_lensing_tutorial.ipynb
@@ -69,19 +69,25 @@
     "cosmo = FlatLambdaCDM(H0=70, Om0=0.3)\n",
     "\n",
     "# define a sky area\n",
-    "sky_area = Quantity(value=0.1, unit='deg2')\n",
+    "sky_area = Quantity(value=0.1, unit=\"deg2\")\n",
     "\n",
     "\n",
     "# define limits in the intrinsic deflector and source population (in addition to the skypy config\n",
     "# file)\n",
-    "kwargs_deflector_cut = {'band': 'g', 'band_max':28, 'z_min': 0.01, 'z_max': 2.5}\n",
-    "kwargs_source_cut = {'band': 'g', 'band_max':28, 'z_min': 0.1, 'z_max': 5.}\n",
+    "kwargs_deflector_cut = {\"band\": \"g\", \"band_max\": 28, \"z_min\": 0.01, \"z_max\": 2.5}\n",
+    "kwargs_source_cut = {\"band\": \"g\", \"band_max\": 28, \"z_min\": 0.1, \"z_max\": 5.0}\n",
     "\n",
     "# run skypy pipeline and make galaxy-galaxy population class using GalaxyGalaxyLensPop\n",
-    "gg_lens_pop = GalaxyGalaxyLensPop(deflector_type='all-galaxies', source_type='galaxies', \n",
-    "                        kwargs_deflector_cut=kwargs_deflector_cut, kwargs_source_cut=\n",
-    "                        kwargs_source_cut, kwargs_mass2light=None, skypy_config=None, \n",
-    "                        sky_area=sky_area, cosmo=cosmo)\n"
+    "gg_lens_pop = GalaxyGalaxyLensPop(\n",
+    "    deflector_type=\"all-galaxies\",\n",
+    "    source_type=\"galaxies\",\n",
+    "    kwargs_deflector_cut=kwargs_deflector_cut,\n",
+    "    kwargs_source_cut=kwargs_source_cut,\n",
+    "    kwargs_mass2light=None,\n",
+    "    skypy_config=None,\n",
+    "    sky_area=sky_area,\n",
+    "    cosmo=cosmo,\n",
+    ")"
    ]
   },
   {
@@ -112,17 +118,25 @@
    },
    "outputs": [],
    "source": [
-    "# make some cuts in the image separations and limited magnitudes of the arc \n",
-    "kwargs_lens_cut_plot = {'min_image_separation': 0.8, 'max_image_separation': 10, \n",
-    "                        'mag_arc_limit': {'g': 23, 'r': 23, 'i': 23}}\n",
+    "# make some cuts in the image separations and limited magnitudes of the arc\n",
+    "kwargs_lens_cut_plot = {\n",
+    "    \"min_image_separation\": 0.8,\n",
+    "    \"max_image_separation\": 10,\n",
+    "    \"mag_arc_limit\": {\"g\": 23, \"r\": 23, \"i\": 23},\n",
+    "}\n",
     "\n",
     "\n",
     "gg_plot = GalaxyGalaxyLensingPlots(gg_lens_pop, num_pix=64, coadd_years=10)\n",
     "\n",
     "# generate montage indicating which bands are used for the rgb color image\n",
-    "fig, axes = gg_plot.plot_montage(rgb_band_list=['i', 'r', 'g'], add_noise=True, n_horizont=5, \n",
-    "                                 n_vertical=2, kwargs_lens_cut=kwargs_lens_cut_plot)\n",
-    "plt.show()\n"
+    "fig, axes = gg_plot.plot_montage(\n",
+    "    rgb_band_list=[\"i\", \"r\", \"g\"],\n",
+    "    add_noise=True,\n",
+    "    n_horizont=5,\n",
+    "    n_vertical=2,\n",
+    "    kwargs_lens_cut=kwargs_lens_cut_plot,\n",
+    ")\n",
+    "plt.show()"
    ]
   },
   {
@@ -151,7 +165,7 @@
    "outputs": [],
    "source": [
     "# specifying cuts of the population\n",
-    "kwargs_lens_cuts = {'mag_arc_limit': {'g': 28}}\n",
+    "kwargs_lens_cuts = {\"mag_arc_limit\": {\"g\": 28}}\n",
     "# drawing population\n",
     "gg_lens_population = gg_lens_pop.draw_population(kwargs_lens_cuts=kwargs_lens_cuts)"
    ]
@@ -181,11 +195,18 @@
    },
    "outputs": [],
    "source": [
-    "print('Number of lenses:', len(gg_lens_population))\n",
+    "print(\"Number of lenses:\", len(gg_lens_population))\n",
     "\n",
     "lens_samples = []\n",
-    "labels = [r'$\\sigma_v$', r'$\\log(M_{*})$', r'$\\theta_E$', r'$z_{\\rm l}$', r'$z_{\\rm s}$', \n",
-    "          r'$m_{\\rm source}$', r'$m_{\\rm lens}$']\n",
+    "labels = [\n",
+    "    r\"$\\sigma_v$\",\n",
+    "    r\"$\\log(M_{*})$\",\n",
+    "    r\"$\\theta_E$\",\n",
+    "    r\"$z_{\\rm l}$\",\n",
+    "    r\"$z_{\\rm s}$\",\n",
+    "    r\"$m_{\\rm source}$\",\n",
+    "    r\"$m_{\\rm lens}$\",\n",
+    "]\n",
     "\n",
     "for gg_lens in gg_lens_population:\n",
     "    vel_disp = gg_lens.deflector_velocity_dispersion()\n",
@@ -193,10 +214,11 @@
     "    theta_e = gg_lens.einstein_radius\n",
     "    zl = gg_lens.lens_redshift\n",
     "    zs = gg_lens.source_redshift\n",
-    "    source_mag = gg_lens.extended_source_magnitude(band='g', lensed=True)\n",
-    "    deflector_mag = gg_lens.deflector_magnitude(band='g')\n",
-    "    lens_samples.append([vel_disp, np.log10(m_star), theta_e, zl, zs, source_mag, deflector_mag])\n",
-    "\n"
+    "    source_mag = gg_lens.extended_source_magnitude(band=\"g\", lensed=True)\n",
+    "    deflector_mag = gg_lens.deflector_magnitude(band=\"g\")\n",
+    "    lens_samples.append(\n",
+    "        [vel_disp, np.log10(m_star), theta_e, zl, zs, source_mag, deflector_mag]\n",
+    "    )"
    ]
   },
   {
@@ -215,8 +237,13 @@
    },
    "outputs": [],
    "source": [
-    "hist2dkwargs = {'plot_density':False, 'plot_contours':False, 'plot_datapoints': True, 'color': 'b',\n",
-    "               'data_kwargs': {'ms': 5}}\n",
+    "hist2dkwargs = {\n",
+    "    \"plot_density\": False,\n",
+    "    \"plot_contours\": False,\n",
+    "    \"plot_datapoints\": True,\n",
+    "    \"color\": \"b\",\n",
+    "    \"data_kwargs\": {\"ms\": 5},\n",
+    "}\n",
     "corner.corner(np.array(lens_samples), labels=labels, **hist2dkwargs)\n",
     "plt.show()"
    ]

--- a/notebooks/lens_source_injection.ipynb
+++ b/notebooks/lens_source_injection.ipynb
@@ -22,11 +22,14 @@
     "from astropy.cosmology import FlatLambdaCDM\n",
     "from astropy.units import Quantity\n",
     "from sim_pipeline.galaxy_galaxy_lens_pop import GalaxyGalaxyLensPop\n",
-    "from sim_pipeline.image_simulation import sharp_image, sharp_rgb_image, rgb_image_from_image_list\n",
+    "from sim_pipeline.image_simulation import (\n",
+    "    sharp_image,\n",
+    "    sharp_rgb_image,\n",
+    "    rgb_image_from_image_list,\n",
+    ")\n",
     "from sim_pipeline.image_simulation import galsimobj_true_flux\n",
     "import mpl_toolkits.axisartist.floating_axes as floating_axes\n",
-    "from mpl_toolkits.axisartist.grid_finder import (MaxNLocator,\n",
-    "                                                 DictFormatter)\n",
+    "from mpl_toolkits.axisartist.grid_finder import MaxNLocator, DictFormatter\n",
     "from matplotlib.transforms import Affine2D\n",
     "import lsst.daf.butler as dafButler\n",
     "import lsst.geom as geom\n",
@@ -95,7 +98,7 @@
    "outputs": [],
    "source": [
     "## Users should change this path to their sim-pipeline path\n",
-    "sys.path.insert(0, '/home/nkhadka/notebooks/mytutorials/sim-pipeline/')"
+    "sys.path.insert(0, \"/home/nkhadka/notebooks/mytutorials/sim-pipeline/\")"
    ]
   },
   {
@@ -118,19 +121,25 @@
     "cosmo = FlatLambdaCDM(H0=70, Om0=0.3)\n",
     "\n",
     "# define a sky area\n",
-    "sky_area = Quantity(value=0.1, unit='deg2')\n",
+    "sky_area = Quantity(value=0.1, unit=\"deg2\")\n",
     "\n",
     "\n",
-    "# define limits in the intrinsic deflector and source population (in addition to the skypy config \n",
+    "# define limits in the intrinsic deflector and source population (in addition to the skypy config\n",
     "# file)\n",
-    "kwargs_deflector_cut = {'band': 'g', 'band_max':28, 'z_min': 0.01, 'z_max': 2.5}\n",
-    "kwargs_source_cut = {'band': 'g', 'band_max':28, 'z_min': 0.1, 'z_max': 5.}\n",
+    "kwargs_deflector_cut = {\"band\": \"g\", \"band_max\": 28, \"z_min\": 0.01, \"z_max\": 2.5}\n",
+    "kwargs_source_cut = {\"band\": \"g\", \"band_max\": 28, \"z_min\": 0.1, \"z_max\": 5.0}\n",
     "\n",
     "# run skypy pipeline and make galaxy-galaxy population class using GalaxyGalaxyLensPop\n",
-    "gg_lens_pop = GalaxyGalaxyLensPop(deflector_type='all-galaxies', source_type='galaxies', \n",
-    "                        kwargs_deflector_cut=kwargs_deflector_cut, kwargs_source_cut =\n",
-    "                        kwargs_source_cut,\n",
-    "                        kwargs_mass2light=None, skypy_config=None, sky_area=sky_area, cosmo=cosmo)"
+    "gg_lens_pop = GalaxyGalaxyLensPop(\n",
+    "    deflector_type=\"all-galaxies\",\n",
+    "    source_type=\"galaxies\",\n",
+    "    kwargs_deflector_cut=kwargs_deflector_cut,\n",
+    "    kwargs_source_cut=kwargs_source_cut,\n",
+    "    kwargs_mass2light=None,\n",
+    "    skypy_config=None,\n",
+    "    sky_area=sky_area,\n",
+    "    cosmo=cosmo,\n",
+    ")"
    ]
   },
   {
@@ -157,9 +166,12 @@
    },
    "outputs": [],
    "source": [
-    "kwargs_lens_cut={'min_image_separation': 0.8, 'max_image_separation': 10, 'mag_arc_limit': \n",
-    "{'g': 23, 'r': 23, 'i': 23}}\n",
-    "rgb_band_list=['i', 'r', 'g']\n",
+    "kwargs_lens_cut = {\n",
+    "    \"min_image_separation\": 0.8,\n",
+    "    \"max_image_separation\": 10,\n",
+    "    \"mag_arc_limit\": {\"g\": 23, \"r\": 23, \"i\": 23},\n",
+    "}\n",
+    "rgb_band_list = [\"i\", \"r\", \"g\"]\n",
     "lens_class = gg_lens_pop.select_lens_at_random(**kwargs_lens_cut)"
    ]
   },
@@ -179,14 +191,14 @@
    },
    "outputs": [],
    "source": [
-    "#print(lens_class.einstein_radius)\n",
-    "#print(lens_class.deflector_velocity_dispersion())\n",
-    "#print(lens_class.deflector_stellar_mass())\n",
-    "#print(lens_class.einstein_radius)\n",
-    "#print(lens_class.lens_redshift)\n",
-    "#print(lens_class.source_redshift)\n",
-    "#print(lens_class.source_magnitude(band='g', lensed=True))\n",
-    "#print(lens_class.deflector_magnitude(band='g'))"
+    "# print(lens_class.einstein_radius)\n",
+    "# print(lens_class.deflector_velocity_dispersion())\n",
+    "# print(lens_class.deflector_stellar_mass())\n",
+    "# print(lens_class.einstein_radius)\n",
+    "# print(lens_class.lens_redshift)\n",
+    "# print(lens_class.source_redshift)\n",
+    "# print(lens_class.source_magnitude(band='g', lensed=True))\n",
+    "# print(lens_class.deflector_magnitude(band='g'))"
    ]
   },
   {
@@ -205,12 +217,27 @@
    },
    "outputs": [],
    "source": [
-    "image_i_1 = sharp_image(lens_class=lens_class, band=rgb_band_list[0], mag_zero_point=27, \n",
-    "delta_pix=0.2, num_pix=200)\n",
-    "image_r_1 = sharp_image(lens_class=lens_class, band=rgb_band_list[1], mag_zero_point=27, \n",
-    "delta_pix=0.2, num_pix=200)\n",
-    "image_g_1 = sharp_image(lens_class=lens_class, band=rgb_band_list[2], mag_zero_point=27, \n",
-    "delta_pix=0.2, num_pix=200)"
+    "image_i_1 = sharp_image(\n",
+    "    lens_class=lens_class,\n",
+    "    band=rgb_band_list[0],\n",
+    "    mag_zero_point=27,\n",
+    "    delta_pix=0.2,\n",
+    "    num_pix=200,\n",
+    ")\n",
+    "image_r_1 = sharp_image(\n",
+    "    lens_class=lens_class,\n",
+    "    band=rgb_band_list[1],\n",
+    "    mag_zero_point=27,\n",
+    "    delta_pix=0.2,\n",
+    "    num_pix=200,\n",
+    ")\n",
+    "image_g_1 = sharp_image(\n",
+    "    lens_class=lens_class,\n",
+    "    band=rgb_band_list[2],\n",
+    "    mag_zero_point=27,\n",
+    "    delta_pix=0.2,\n",
+    "    num_pix=200,\n",
+    ")"
    ]
   },
   {
@@ -229,8 +256,8 @@
    },
    "outputs": [],
    "source": [
-    "#image_g.shape\n",
-    "plt.imshow(image_r_1, origin='lower')"
+    "# image_g.shape\n",
+    "plt.imshow(image_r_1, origin=\"lower\")"
    ]
   },
   {
@@ -249,8 +276,13 @@
    },
    "outputs": [],
    "source": [
-    "high_reso_rgb=sharp_rgb_image(lens_class=lens_class, rgb_band_list=rgb_band_list, mag_zero_point=27,\n",
-    " delta_pix=0.2, num_pix=200)"
+    "high_reso_rgb = sharp_rgb_image(\n",
+    "    lens_class=lens_class,\n",
+    "    rgb_band_list=rgb_band_list,\n",
+    "    mag_zero_point=27,\n",
+    "    delta_pix=0.2,\n",
+    "    num_pix=200,\n",
+    ")"
    ]
   },
   {
@@ -269,7 +301,7 @@
    },
    "outputs": [],
    "source": [
-    "plt.imshow(high_reso_rgb, origin='lower')"
+    "plt.imshow(high_reso_rgb, origin=\"lower\")"
    ]
   },
   {
@@ -304,9 +336,9 @@
    },
    "outputs": [],
    "source": [
-    "gsobj_r=galsimobj_true_flux(image_r_1, pix_scale=0.2)\n",
-    "gsobj_g=galsimobj_true_flux(image_g_1, pix_scale=0.2)\n",
-    "gsobj_i=galsimobj_true_flux(image_i_1, pix_scale=0.2)"
+    "gsobj_r = galsimobj_true_flux(image_r_1, pix_scale=0.2)\n",
+    "gsobj_g = galsimobj_true_flux(image_g_1, pix_scale=0.2)\n",
+    "gsobj_i = galsimobj_true_flux(image_i_1, pix_scale=0.2)"
    ]
   },
   {
@@ -326,19 +358,19 @@
    "outputs": [],
    "source": [
     "config = \"dp02\"\n",
-    "collection ='2.2i/runs/DP0.2'\n",
+    "collection = \"2.2i/runs/DP0.2\"\n",
     "butler = dafButler.Butler(config, collections=collection)\n",
     "skymap = butler.get(\"skyMap\")\n",
     "\n",
     "# Near the center of DC2\n",
-    "ra = 62.541629   # degrees\n",
-    "dec = -37.852021 # degrees\n",
+    "ra = 62.541629  # degrees\n",
+    "dec = -37.852021  # degrees\n",
     "point = geom.SpherePoint(ra, dec, geom.degrees)\n",
     "cutoutSize = geom.ExtentI(201, 201)\n",
-    "#print(cutoutSize)\n",
+    "# print(cutoutSize)\n",
     "\n",
     "\n",
-    "#Read this from the table we have at hand... \n",
+    "# Read this from the table we have at hand...\n",
     "tractInfo = skymap.findTract(point)\n",
     "patchInfo = tractInfo.findPatch(point)\n",
     "my_tract = tractInfo.tract_id\n",
@@ -346,15 +378,11 @@
     "\n",
     "xy = geom.PointI(tractInfo.getWcs().skyToPixel(point))\n",
     "\n",
-    "bbox = geom.BoxI(xy + cutoutSize//2, cutoutSize)\n",
+    "bbox = geom.BoxI(xy + cutoutSize // 2, cutoutSize)\n",
     "\n",
-    "coaddId_r = {\n",
-    "    'tract':my_tract, \n",
-    "    'patch':my_patch,\n",
-    "    'band':'i'\n",
-    "}\n",
+    "coaddId_r = {\"tract\": my_tract, \"patch\": my_patch, \"band\": \"i\"}\n",
     "coadd = butler.get(\"deepCoadd\", dataId=coaddId_r)\n",
-    "coadd_cut_r = butler.get(\"deepCoadd\",parameters={'bbox':bbox}, dataId=coaddId_r)"
+    "coadd_cut_r = butler.get(\"deepCoadd\", parameters={\"bbox\": bbox}, dataId=coaddId_r)"
    ]
   },
   {
@@ -373,18 +401,10 @@
    },
    "outputs": [],
    "source": [
-    "coaddId_g = {\n",
-    "    'tract':3638, \n",
-    "    'patch':27,\n",
-    "    'band':'g'\n",
-    "}\n",
-    "coaddId_i = {\n",
-    "    'tract':3638, \n",
-    "    'patch':27,\n",
-    "    'band':'i'\n",
-    "}\n",
-    "coadd_cut_g = butler.get(\"deepCoadd\",parameters={'bbox':bbox}, dataId=coaddId_g)\n",
-    "coadd_cut_i = butler.get(\"deepCoadd\",parameters={'bbox':bbox}, dataId=coaddId_i)"
+    "coaddId_g = {\"tract\": 3638, \"patch\": 27, \"band\": \"g\"}\n",
+    "coaddId_i = {\"tract\": 3638, \"patch\": 27, \"band\": \"i\"}\n",
+    "coadd_cut_g = butler.get(\"deepCoadd\", parameters={\"bbox\": bbox}, dataId=coaddId_g)\n",
+    "coadd_cut_i = butler.get(\"deepCoadd\", parameters={\"bbox\": bbox}, dataId=coaddId_i)"
    ]
   },
   {
@@ -403,7 +423,7 @@
    },
    "outputs": [],
    "source": [
-    "afwDisplay.setDefaultBackend('matplotlib')"
+    "afwDisplay.setDefaultBackend(\"matplotlib\")"
    ]
   },
   {
@@ -424,9 +444,9 @@
    "source": [
     "fig = plt.figure(figsize=(10, 8))\n",
     "afw_display = afwDisplay.Display(1)\n",
-    "afw_display.scale('asinh', 'zscale')\n",
+    "afw_display.scale(\"asinh\", \"zscale\")\n",
     "afw_display.mtv(coadd.image)\n",
-    "plt.gca().axis('on')"
+    "plt.gca().axis(\"on\")"
    ]
   },
   {
@@ -455,9 +475,9 @@
    "source": [
     "fig = plt.figure(figsize=(10, 8))\n",
     "afw_display = afwDisplay.Display(1)\n",
-    "afw_display.scale('asinh', 'zscale')\n",
+    "afw_display.scale(\"asinh\", \"zscale\")\n",
     "afw_display.mtv(coadd_cut_r.image)\n",
-    "plt.gca().axis('on')"
+    "plt.gca().axis(\"on\")"
    ]
   },
   {
@@ -493,11 +513,11 @@
    },
    "outputs": [],
    "source": [
-    "# This is a function which takes a simulated lens (in the form of gsobj) and injects in a dp0 \n",
+    "# This is a function which takes a simulated lens (in the form of gsobj) and injects in a dp0\n",
     "# cutout image.\n",
     "def injection(coadd_image, coaddId, gsobj):\n",
-    "    wcs= coadd_image.getWcs()\n",
-    "    bbox= coadd_image.getBBox()\n",
+    "    wcs = coadd_image.getWcs()\n",
+    "    bbox = coadd_image.getBBox()\n",
     "    x_min = bbox.getMinX()\n",
     "    y_min = bbox.getMinY()\n",
     "    x_max = bbox.getMaxX()\n",
@@ -508,28 +528,28 @@
     "    y_center = (y_min + y_max) / 2\n",
     "\n",
     "    center = geom.Point2D(x_center, y_center)\n",
-    "    #geom.Point2D(26679, 15614)\n",
-    "    point=wcs.pixelToSky(center)\n",
+    "    # geom.Point2D(26679, 15614)\n",
+    "    point = wcs.pixelToSky(center)\n",
     "    print(point)\n",
     "\n",
-    "    image = butler.get(\"deepCoadd\", parameters={'bbox':bbox}, dataId=coaddId)\n",
+    "    image = butler.get(\"deepCoadd\", parameters={\"bbox\": bbox}, dataId=coaddId)\n",
     "    mat = np.eye(3)\n",
-    "    mat[:2,:2] = wcs.getCdMatrix()\n",
+    "    mat[:2, :2] = wcs.getCdMatrix()\n",
     "\n",
     "    transform = Affine2D(mat)\n",
     "    fig = plt.figure(figsize=(20, 18))\n",
     "    arr = np.copy(image.image.array)\n",
     "    plot_extents = 0, bbox.width, 0, bbox.height\n",
     "    helper = floating_axes.GridHelperCurveLinear(\n",
-    "        transform, plot_extents, \n",
+    "        transform,\n",
+    "        plot_extents,\n",
     "        tick_formatter1=DictFormatter({}),\n",
     "        tick_formatter2=DictFormatter({}),\n",
     "        grid_locator1=MaxNLocator(nbins=1),\n",
     "        grid_locator2=MaxNLocator(nbins=1),\n",
-    "\n",
     "    )\n",
     "    ax = floating_axes.FloatingSubplot(fig, 132, grid_helper=helper)\n",
-    "    ax.imshow((arr), vmin=0, transform=transform+ax.transData, origin='lower')\n",
+    "    ax.imshow((arr), vmin=0, transform=transform + ax.transData, origin=\"lower\")\n",
     "\n",
     "    fig.add_subplot(ax)\n",
     "    print(point)\n",
@@ -537,22 +557,25 @@
     "    inj_arr = image.image.array\n",
     "    plot_extents = 0, bbox.width, 0, bbox.height\n",
     "    helper = floating_axes.GridHelperCurveLinear(\n",
-    "        transform, plot_extents, \n",
+    "        transform,\n",
+    "        plot_extents,\n",
     "        tick_formatter1=DictFormatter({}),\n",
     "        tick_formatter2=DictFormatter({}),\n",
     "        grid_locator1=MaxNLocator(nbins=1),\n",
     "        grid_locator2=MaxNLocator(nbins=1),\n",
     "    )\n",
     "    ax = floating_axes.FloatingSubplot(fig, 133, grid_helper=helper)\n",
-    "    ax.imshow((inj_arr), vmin=0, transform=transform+ax.transData, origin='lower')\n",
+    "    ax.imshow((inj_arr), vmin=0, transform=transform + ax.transData, origin=\"lower\")\n",
     "\n",
     "    fig.add_subplot(ax)\n",
     "\n",
     "    ax = floating_axes.FloatingSubplot(fig, 131, grid_helper=helper)\n",
-    "    ax.imshow((inj_arr-arr), vmin=0, transform=transform+ax.transData, origin='lower')\n",
+    "    ax.imshow(\n",
+    "        (inj_arr - arr), vmin=0, transform=transform + ax.transData, origin=\"lower\"\n",
+    "    )\n",
     "\n",
     "    fig.add_subplot(ax)\n",
-    "    #fig.suptitle(repr(coaddId))\n",
+    "    # fig.suptitle(repr(coaddId))\n",
     "    return fig.show(), inj_arr, arr"
    ]
   },
@@ -671,10 +694,10 @@
     "arr_g = injection_in_g_band[2]\n",
     "arr_r = injection_in_r_band[2]\n",
     "\n",
-    "image_list=[inj_arr_i, inj_arr_r, inj_arr_g]\n",
-    "image_list_1=[arr_i, arr_r, arr_g]\n",
-    "final_injected_image=rgb_image_from_image_list(image_list=image_list, stretch=2)\n",
-    "final_uninjected_image=rgb_image_from_image_list(image_list=image_list_1, stretch=2)"
+    "image_list = [inj_arr_i, inj_arr_r, inj_arr_g]\n",
+    "image_list_1 = [arr_i, arr_r, arr_g]\n",
+    "final_injected_image = rgb_image_from_image_list(image_list=image_list, stretch=2)\n",
+    "final_uninjected_image = rgb_image_from_image_list(image_list=image_list_1, stretch=2)"
    ]
   },
   {
@@ -693,7 +716,7 @@
    },
    "outputs": [],
    "source": [
-    "plt.imshow(final_uninjected_image, extent = [0, bbox.width, 0, bbox.height])"
+    "plt.imshow(final_uninjected_image, extent=[0, bbox.width, 0, bbox.height])"
    ]
   },
   {
@@ -712,7 +735,7 @@
    },
    "outputs": [],
    "source": [
-    "plt.imshow(final_injected_image,extent = [0, bbox.width, 0, bbox.height])"
+    "plt.imshow(final_injected_image, extent=[0, bbox.width, 0, bbox.height])"
    ]
   },
   {
@@ -731,7 +754,10 @@
    },
    "outputs": [],
    "source": [
-    "plt.imshow(final_injected_image-final_uninjected_image, extent = [0, bbox.width, 0, bbox.height])"
+    "plt.imshow(\n",
+    "    final_injected_image - final_uninjected_image,\n",
+    "    extent=[0, bbox.width, 0, bbox.height],\n",
+    ")"
    ]
   },
   {
@@ -759,8 +785,8 @@
    },
    "outputs": [],
    "source": [
-    "ra = 62.541629   # degrees\n",
-    "dec = -37.852021 # degrees"
+    "ra = 62.541629  # degrees\n",
+    "dec = -37.852021  # degrees"
    ]
   },
   {
@@ -779,7 +805,9 @@
    },
    "outputs": [],
    "source": [
-    "y=lsst_science_pipeline.lens_inejection(gg_lens_pop, 201, 0.2, butler, ra, dec, flux=None)"
+    "y = lsst_science_pipeline.lens_inejection(\n",
+    "    gg_lens_pop, 201, 0.2, butler, ra, dec, flux=None\n",
+    ")"
    ]
   },
   {
@@ -798,7 +826,7 @@
    },
    "outputs": [],
    "source": [
-    "## This line should display an astropy table containg lens image,dp0 cutout_image, injected_lens \n",
+    "## This line should display an astropy table containg lens image,dp0 cutout_image, injected_lens\n",
     "## in r, g, and i band and  center of the dp0 cutout images.\n",
     "y"
    ]

--- a/notebooks/multiple_lens_injection.ipynb
+++ b/notebooks/multiple_lens_injection.ipynb
@@ -53,7 +53,7 @@
    "outputs": [],
    "source": [
     "## Users should change this path to their sim-pipeline path\n",
-    "sys.path.insert(0, '/home/nkhadka/notebooks/mytutorials/sim-pipeline/')"
+    "sys.path.insert(0, \"/home/nkhadka/notebooks/mytutorials/sim-pipeline/\")"
    ]
   },
   {
@@ -84,18 +84,24 @@
     "cosmo = FlatLambdaCDM(H0=70, Om0=0.3)\n",
     "\n",
     "# define a sky area\n",
-    "sky_area = Quantity(value=0.1, unit='deg2')\n",
+    "sky_area = Quantity(value=0.1, unit=\"deg2\")\n",
     "\n",
-    "# define limits in the intrinsic deflector and source population (in addition to the skypy config \n",
+    "# define limits in the intrinsic deflector and source population (in addition to the skypy config\n",
     "# file)\n",
-    "kwargs_deflector_cut = {'band': 'g', 'band_max':28, 'z_min': 0.01, 'z_max': 2.5}\n",
-    "kwargs_source_cut = {'band': 'g', 'band_max':28, 'z_min': 0.1, 'z_max': 5.}\n",
+    "kwargs_deflector_cut = {\"band\": \"g\", \"band_max\": 28, \"z_min\": 0.01, \"z_max\": 2.5}\n",
+    "kwargs_source_cut = {\"band\": \"g\", \"band_max\": 28, \"z_min\": 0.1, \"z_max\": 5.0}\n",
     "\n",
     "# run skypy pipeline and make galaxy-galaxy population class using GalaxyGalaxyLensPop\n",
-    "gg_lens_pop = GalaxyGalaxyLensPop(deflector_type='all-galaxies', source_type='galaxies', \n",
-    "                        kwargs_deflector_cut=kwargs_deflector_cut, kwargs_source_cut=\n",
-    "                        kwargs_source_cut,kwargs_mass2light=None, skypy_config=None, \n",
-    "                        sky_area=sky_area, cosmo=cosmo)"
+    "gg_lens_pop = GalaxyGalaxyLensPop(\n",
+    "    deflector_type=\"all-galaxies\",\n",
+    "    source_type=\"galaxies\",\n",
+    "    kwargs_deflector_cut=kwargs_deflector_cut,\n",
+    "    kwargs_source_cut=kwargs_source_cut,\n",
+    "    kwargs_mass2light=None,\n",
+    "    skypy_config=None,\n",
+    "    sky_area=sky_area,\n",
+    "    cosmo=cosmo,\n",
+    ")"
    ]
   },
   {
@@ -149,7 +155,7 @@
    "outputs": [],
    "source": [
     "config = \"dp02\"\n",
-    "collection ='2.2i/runs/DP0.2'\n",
+    "collection = \"2.2i/runs/DP0.2\"\n",
     "butler = dafButler.Butler(config, collections=collection)\n",
     "skymap = butler.get(\"skyMap\")"
    ]
@@ -204,7 +210,7 @@
    "outputs": [],
    "source": [
     "##provide minimum and maximum limits for ra and dec. Also, specify how many ra, dec pair you want.\n",
-    "ra, dec=param_util.random_ra_dec(55, 70, -43, -30, 100)"
+    "ra, dec = param_util.random_ra_dec(55, 70, -43, -30, 100)"
    ]
   },
   {
@@ -223,13 +229,17 @@
    },
    "outputs": [],
    "source": [
-    "## specify pixel number and pixel scale of the images. Here we have chosen 64 and 0.2 respectively. \n",
+    "## specify pixel number and pixel scale of the images. Here we have chosen 64 and 0.2 respectively.\n",
     "## We should choose pixel scale = 0.2 to match the pixel scale scale of DC2 data.\n",
     "## For this function one lens_cut. If not provided, default option is None.\n",
-    "lens_cut = {'min_image_separation': 0.8, 'max_image_separation': 10, \n",
-    "                        'mag_arc_limit': {'g': 23, 'r': 23, 'i': 23}}\n",
-    "injected_lens_catalog=lsst_science_pipeline.multiple_lens_injection(gg_lens_pop, 64, 0.2, ra, dec, butler, \n",
-    "lens_cut=lens_cut, flux=None)"
+    "lens_cut = {\n",
+    "    \"min_image_separation\": 0.8,\n",
+    "    \"max_image_separation\": 10,\n",
+    "    \"mag_arc_limit\": {\"g\": 23, \"r\": 23, \"i\": 23},\n",
+    "}\n",
+    "injected_lens_catalog = lsst_science_pipeline.multiple_lens_injection(\n",
+    "    gg_lens_pop, 64, 0.2, ra, dec, butler, lens_cut=lens_cut, flux=None\n",
+    ")"
    ]
   },
   {
@@ -248,7 +258,7 @@
    },
    "outputs": [],
    "source": [
-    "## This line should display an astropy table containg lens image,dp0 cutout_image, injected_lens \n",
+    "## This line should display an astropy table containg lens image,dp0 cutout_image, injected_lens\n",
     "## in r, g, and i band and  center of the dp0 cutout images.\n",
     "injected_lens_catalog"
    ]
@@ -279,13 +289,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## This line should display an astropy table containg lens image,dp0 cutout_image, injected_lens \n",
+    "## This line should display an astropy table containg lens image,dp0 cutout_image, injected_lens\n",
     "## in r, g, and i band and  center of the dp0 cutout images\n",
-    "kwargs_lens_cut={'min_image_separation': 0.8, 'max_image_separation': 10, \n",
-    "                 'mag_arc_limit': {'g': 23, 'r': 23, 'i': 23}}\n",
-    "ra_2, dec_2=param_util.random_ra_dec(55, 70, -43, -30, 10)\n",
-    "injected_lens_catalog_2 = lsst_science_pipeline.multiple_lens_injection_fast(gg_lens_pop, 100, 0.2, \n",
-    "                                                    butler, ra, dec, 10, kwargs_lens_cut, flux=None)\n",
+    "kwargs_lens_cut = {\n",
+    "    \"min_image_separation\": 0.8,\n",
+    "    \"max_image_separation\": 10,\n",
+    "    \"mag_arc_limit\": {\"g\": 23, \"r\": 23, \"i\": 23},\n",
+    "}\n",
+    "ra_2, dec_2 = param_util.random_ra_dec(55, 70, -43, -30, 10)\n",
+    "injected_lens_catalog_2 = lsst_science_pipeline.multiple_lens_injection_fast(\n",
+    "    gg_lens_pop, 100, 0.2, butler, ra, dec, 10, kwargs_lens_cut, flux=None\n",
+    ")\n",
     "injected_lens_catalog_2"
    ]
   }

--- a/setup.py
+++ b/setup.py
@@ -4,41 +4,43 @@
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open("README.rst") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
-requirements = [ ]
+requirements = []
 
-test_requirements = ['pytest>=3', ]
+test_requirements = [
+    "pytest>=3",
+]
 
 setup(
     author="DESC/SLSC",
-    author_email='sibirrer@gmail.com',
-    python_requires='>=3.6',
+    author_email="sibirrer@gmail.com",
+    python_requires=">=3.6",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     description="LSST strong lensing simulation pipeline",
     install_requires=requirements,
     license="MIT license",
-    long_description=readme + '\n\n' + history,
+    long_description=readme + "\n\n" + history,
     include_package_data=True,
-    keywords='sim_pipeline',
-    name='sim_pipeline',
-    packages=find_packages(include=['sim_pipeline', 'sim_pipeline.*']),
-    test_suite='tests',
+    keywords="sim_pipeline",
+    name="sim_pipeline",
+    packages=find_packages(include=["sim_pipeline", "sim_pipeline.*"]),
+    test_suite="tests",
     tests_require=test_requirements,
-    url='https://github.com/LSST-strong-lensing/sim_pipeline',
-    version='0.1.0',
+    url="https://github.com/LSST-strong-lensing/sim_pipeline",
+    version="0.1.0",
     zip_safe=False,
 )

--- a/sim_pipeline/Deflectors/all_lens_galaxies.py
+++ b/sim_pipeline/Deflectors/all_lens_galaxies.py
@@ -6,14 +6,25 @@ import numpy.random as random
 from astropy.table import vstack
 from sim_pipeline.selection import galaxy_cut
 from sim_pipeline.Deflectors.velocity_dispersion import vel_disp_sdss
-from sim_pipeline.Deflectors.elliptical_lens_galaxies import elliptical_projected_eccentricity
+from sim_pipeline.Deflectors.elliptical_lens_galaxies import (
+    elliptical_projected_eccentricity,
+)
 
 
 class AllLensGalaxies(object):
     """
     class describing all-type galaxies
     """
-    def __init__(self, red_galaxy_list, blue_galaxy_list, kwargs_cut, kwargs_mass2light, cosmo, sky_area):
+
+    def __init__(
+        self,
+        red_galaxy_list,
+        blue_galaxy_list,
+        kwargs_cut,
+        kwargs_mass2light,
+        cosmo,
+        sky_area,
+    ):
         """
 
         :param red_galaxy_list: list of dictionary with galaxy parameters of elliptical galaxies
@@ -28,21 +39,25 @@ class AllLensGalaxies(object):
         :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid angle.
         """
         red_column_names = red_galaxy_list.colnames
-        if 'galaxy_type' not in red_column_names:
-            red_galaxy_list['galaxy_type'] = 'red'
+        if "galaxy_type" not in red_column_names:
+            red_galaxy_list["galaxy_type"] = "red"
 
         blue_column_names = blue_galaxy_list.colnames
-        if 'galaxy_type' not in blue_column_names:
-            blue_galaxy_list['galaxy_type'] = 'blue'
+        if "galaxy_type" not in blue_column_names:
+            blue_galaxy_list["galaxy_type"] = "blue"
 
         red_galaxy_list = fill_table(red_galaxy_list)
         blue_galaxy_list = fill_table(blue_galaxy_list)
         galaxy_list = vstack([red_galaxy_list, blue_galaxy_list])
-        self._f_vel_disp = vel_disp_abundance_matching(galaxy_list, z_max=0.5, sky_area=sky_area, cosmo=cosmo)
+        self._f_vel_disp = vel_disp_abundance_matching(
+            galaxy_list, z_max=0.5, sky_area=sky_area, cosmo=cosmo
+        )
 
         self._galaxy_select = galaxy_cut(galaxy_list, **kwargs_cut)
         self._num_select = len(self._galaxy_select)
-        self._galaxy_select['vel_disp'] = self._f_vel_disp(np.log10(self._galaxy_select['stellar_mass']))
+        self._galaxy_select["vel_disp"] = self._f_vel_disp(
+            np.log10(self._galaxy_select["stellar_mass"])
+        )
         # TODO: random reshuffle of matched list
 
     def deflector_number(self):
@@ -61,14 +76,16 @@ class AllLensGalaxies(object):
 
         index = random.randint(0, self._num_select - 1)
         deflector = self._galaxy_select[index]
-        if deflector['e1_light'] == -1 or deflector['e2_light'] == - 1:
-            e1_light, e2_light, e1_mass, e2_mass = elliptical_projected_eccentricity(**deflector)
-            deflector['e1_light'] = e1_light
-            deflector['e2_light'] = e2_light
-            deflector['e1_mass'] = e1_mass
-            deflector['e2_mass'] = e2_mass
-        if deflector['n_sersic'] == -1:
-            deflector['n_sersic'] = 4  # TODO make a better estimate with scatter
+        if deflector["e1_light"] == -1 or deflector["e2_light"] == -1:
+            e1_light, e2_light, e1_mass, e2_mass = elliptical_projected_eccentricity(
+                **deflector
+            )
+            deflector["e1_light"] = e1_light
+            deflector["e2_light"] = e2_light
+            deflector["e1_mass"] = e1_mass
+            deflector["e2_mass"] = e2_mass
+        if deflector["n_sersic"] == -1:
+            deflector["n_sersic"] = 4  # TODO make a better estimate with scatter
         return deflector
 
 
@@ -80,16 +97,16 @@ def fill_table(galaxy_list):
     """
     n = len(galaxy_list)
     column_names = galaxy_list.colnames
-    if 'vel_disp' not in column_names:
-        galaxy_list['vel_disp'] = -np.ones(n)
-    if 'e1_light' not in column_names or 'e2_light' not in column_names:
-        galaxy_list['e1_light'] = -np.ones(n)
-        galaxy_list['e2_light'] = -np.ones(n)
-    if 'e1_mass' not in column_names or 'e2_mass' not in column_names:
-        galaxy_list['e1_mass'] = -np.ones(n)
-        galaxy_list['e2_mass'] = -np.ones(n)
-    if 'n_sersic' not in column_names:
-        galaxy_list['n_sersic'] = -np.ones(n)
+    if "vel_disp" not in column_names:
+        galaxy_list["vel_disp"] = -np.ones(n)
+    if "e1_light" not in column_names or "e2_light" not in column_names:
+        galaxy_list["e1_light"] = -np.ones(n)
+        galaxy_list["e2_light"] = -np.ones(n)
+    if "e1_mass" not in column_names or "e2_mass" not in column_names:
+        galaxy_list["e1_mass"] = -np.ones(n)
+        galaxy_list["e2_mass"] = -np.ones(n)
+    if "n_sersic" not in column_names:
+        galaxy_list["n_sersic"] = -np.ones(n)
     return galaxy_list
 
 
@@ -105,33 +122,39 @@ def vel_disp_abundance_matching(galaxy_list, z_max, sky_area, cosmo):
     :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid angle.
     :return: interpolation function f; f(stellar_mass) -> vel_disp
     """
-    bool_cut = (galaxy_list['z'] < z_max)
+    bool_cut = galaxy_list["z"] < z_max
     galaxy_list_zmax = copy.deepcopy(galaxy_list[bool_cut])
     num_select = len(galaxy_list_zmax)
 
-    redshift = np.arange(0, z_max+0.001, 0.1)
-    z_list, vel_disp_list = vel_disp_sdss(sky_area, redshift, vd_min=50, vd_max=500, cosmology=cosmo, noise=True)
+    redshift = np.arange(0, z_max + 0.001, 0.1)
+    z_list, vel_disp_list = vel_disp_sdss(
+        sky_area, redshift, vd_min=50, vd_max=500, cosmology=cosmo, noise=True
+    )
 
     # sort for stellar masses, largest values first
-    galaxy_list_zmax.sort('stellar_mass')
+    galaxy_list_zmax.sort("stellar_mass")
     galaxy_list_zmax.reverse()
     # sort velocity dispersion, largest values first
     vel_disp_list = np.flip(np.sort(vel_disp_list))
     num_vel_disp = len(vel_disp_list)
     # abundance match velocity dispersion with elliptical galaxy catalogue
     if num_vel_disp >= num_select:
-        galaxy_list_zmax['vel_disp'] = vel_disp_list[:num_select]
+        galaxy_list_zmax["vel_disp"] = vel_disp_list[:num_select]
         # randomly select
     else:
         galaxy_list_zmax = galaxy_list_zmax[:num_vel_disp]
-        galaxy_list_zmax['vel_disp'] = vel_disp_list
+        galaxy_list_zmax["vel_disp"] = vel_disp_list
     # interpolate relationship between stellar mass and velocity dispersion
-    stellar_mass = np.asarray(galaxy_list_zmax['stellar_mass'])
-    vel_disp = np.asarray(galaxy_list_zmax['vel_disp'])
+    stellar_mass = np.asarray(galaxy_list_zmax["stellar_mass"])
+    vel_disp = np.asarray(galaxy_list_zmax["vel_disp"])
 
     # here we make sure we interpolate to low stellar masses
     stellar_mass = np.append(stellar_mass, 10**5)
     vel_disp = np.append(vel_disp, 10)
-    f = interpolate.interp1d(x=np.log10(stellar_mass), y=vel_disp,
-                             fill_value=(0, np.max(galaxy_list_zmax['vel_disp'])), bounds_error=False)
+    f = interpolate.interp1d(
+        x=np.log10(stellar_mass),
+        y=vel_disp,
+        fill_value=(0, np.max(galaxy_list_zmax["vel_disp"])),
+        bounds_error=False,
+    )
     return f

--- a/sim_pipeline/Deflectors/all_lens_galaxies.py
+++ b/sim_pipeline/Deflectors/all_lens_galaxies.py
@@ -12,9 +12,7 @@ from sim_pipeline.Deflectors.elliptical_lens_galaxies import (
 
 
 class AllLensGalaxies(object):
-    """
-    class describing all-type galaxies
-    """
+    """Class describing all-type galaxies."""
 
     def __init__(
         self,
@@ -111,8 +109,7 @@ def fill_table(galaxy_list):
 
 
 def vel_disp_abundance_matching(galaxy_list, z_max, sky_area, cosmo):
-    """
-    function for calculate the velocity dispersion from the staller mass
+    """Function for calculate the velocity dispersion from the staller mass.
 
     :param galaxy_list: list of galaxies with stellar masses given
     :type galaxy_list: ~astropy.Table object

--- a/sim_pipeline/Deflectors/all_lens_galaxies.py
+++ b/sim_pipeline/Deflectors/all_lens_galaxies.py
@@ -25,16 +25,17 @@ class AllLensGalaxies(object):
     ):
         """
 
-        :param red_galaxy_list: list of dictionary with galaxy parameters of elliptical galaxies
-         (currently supporting skypy pipelines)
-        :param blue_galaxy_list: list of dictionary with galaxy parameters of spiral galaxies
-         (currently supporting skypy pipelines)
+        :param red_galaxy_list: list of dictionary with galaxy parameters of elliptical
+            galaxies (currently supporting skypy pipelines)
+        :param blue_galaxy_list: list of dictionary with galaxy parameters of spiral
+        galaxies (currently supporting skypy pipelines)
         :param kwargs_cut: cuts in parameters
         :type kwargs_cut: dict
         :param kwargs_mass2light: mass-to-light relation
         :param cosmo: astropy.cosmology instance
         :type sky_area: `~astropy.units.Quantity`
-        :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid angle.
+        :param sky_area: Sky area over which galaxies are sampled. Must be in units of
+            solid angle.
         """
         red_column_names = red_galaxy_list.colnames
         if "galaxy_type" not in red_column_names:
@@ -113,10 +114,12 @@ def vel_disp_abundance_matching(galaxy_list, z_max, sky_area, cosmo):
 
     :param galaxy_list: list of galaxies with stellar masses given
     :type galaxy_list: ~astropy.Table object
-    :param z_max: maximum redshift to which the abundance matching with the SDSS velocity dispersion function is valid
+    :param z_max: maximum redshift to which the abundance matching with the SDSS
+        velocity dispersion function is valid
     :param cosmo: astropy.cosmology instance
     :type sky_area: `~astropy.units.Quantity`
-    :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid angle.
+    :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid
+        angle.
     :return: interpolation function f; f(stellar_mass) -> vel_disp
     """
     bool_cut = galaxy_list["z"] < z_max

--- a/sim_pipeline/Deflectors/elliptical_lens_galaxies.py
+++ b/sim_pipeline/Deflectors/elliptical_lens_galaxies.py
@@ -6,9 +6,7 @@ from sim_pipeline.Util import param_util
 
 
 class EllipticalLensGalaxies(object):
-    """
-    class describing elliptical galaxies
-    """
+    """Class describing elliptical galaxies."""
 
     def __init__(self, galaxy_list, kwargs_cut, kwargs_mass2light, cosmo, sky_area):
         """
@@ -94,8 +92,8 @@ class EllipticalLensGalaxies(object):
 
 
 def elliptical_projected_eccentricity(ellipticity, **kwargs):
-    """
-    projected eccentricity of elliptical galaxies as a function of other deflector parameters
+    """Projected eccentricity of elliptical galaxies as a function of other deflector
+    parameters.
 
     :param ellipticity: eccentricity amplitude
     :type ellipticity: float [0,1)
@@ -115,9 +113,8 @@ def elliptical_projected_eccentricity(ellipticity, **kwargs):
 
 
 def vel_disp_from_m_star(m_star):
-    """
-    Function to calculate the velocity dispersion from the staller mass using empirical relation for
-    elliptical galaxies
+    """Function to calculate the velocity dispersion from the staller mass using
+    empirical relation for elliptical galaxies.
 
     The power-law formula is given by:
 
@@ -131,7 +128,6 @@ def vel_disp_from_m_star(m_star):
 
     :param m_star: stellar mass in the unit of solar mass
     :return: the velocity dispersion ("km/s")
-
     """
     v_disp = np.power(10, 2.32) * np.power(m_star / 1e11, 0.24)
     return v_disp

--- a/sim_pipeline/Deflectors/elliptical_lens_galaxies.py
+++ b/sim_pipeline/Deflectors/elliptical_lens_galaxies.py
@@ -11,14 +11,15 @@ class EllipticalLensGalaxies(object):
     def __init__(self, galaxy_list, kwargs_cut, kwargs_mass2light, cosmo, sky_area):
         """
 
-        :param galaxy_list: list of dictionary with galaxy parameters of elliptical galaxies
-         (currently supporting skypy pipelines)
+        :param galaxy_list: list of dictionary with galaxy parameters of elliptical
+            galaxies (currently supporting skypy pipelines)
         :param kwargs_cut: cuts in parameters
         :type kwargs_cut: dict
         :param kwargs_mass2light: mass-to-light relation
         :param cosmo: astropy.cosmology instance
         :type sky_area: `~astropy.units.Quantity`
-        :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid angle.
+        :param sky_area: Sky area over which galaxies are sampled. Must be in units of
+            solid angle.
         """
         n = len(galaxy_list)
         column_names = galaxy_list.colnames
@@ -120,11 +121,13 @@ def vel_disp_from_m_star(m_star):
 
     .. math::
 
-         V_{\\mathrm{disp}} = 10^{2.32} \\left( \\frac{M_{\\mathrm{star}}}{10^{11} M_\\odot} \\right)^{0.24}
+         V_{\\mathrm{disp}} = 10^{2.32} \\left( \\frac{M_{\\mathrm{star}}}{10^{11}
+         M_\\odot} \\right)^{0.24}
 
     2.32,0.24 is the parameters from [1] table 2
-    [1]:Auger, M. W., et al. "The Sloan Lens ACS Survey. X. Stellar, dynamical, and total mass correlations of massive
-    elliptical galaxies." The Astrophysical Journal 724.1 (2010): 511.
+    [1]:Auger, M. W., et al. "The Sloan Lens ACS Survey. X. Stellar, dynamical, and
+    total mass correlations of massive elliptical galaxies." The Astrophysical
+    Journal 724.1 (2010): 511.
 
     :param m_star: stellar mass in the unit of solar mass
     :return: the velocity dispersion ("km/s")

--- a/sim_pipeline/Deflectors/elliptical_lens_galaxies.py
+++ b/sim_pipeline/Deflectors/elliptical_lens_galaxies.py
@@ -9,6 +9,7 @@ class EllipticalLensGalaxies(object):
     """
     class describing elliptical galaxies
     """
+
     def __init__(self, galaxy_list, kwargs_cut, kwargs_mass2light, cosmo, sky_area):
         """
 
@@ -23,36 +24,38 @@ class EllipticalLensGalaxies(object):
         """
         n = len(galaxy_list)
         column_names = galaxy_list.colnames
-        if 'vel_disp' not in column_names:
-            galaxy_list['vel_disp'] = -np.ones(n)
-        if 'e1_light' not in column_names or 'e2_light' not in column_names:
-            galaxy_list['e1_light'] = -np.ones(n)
-            galaxy_list['e2_light'] = -np.ones(n)
-        if 'e1_mass' not in column_names or 'e2_mass' not in column_names:
-            galaxy_list['e1_mass'] = -np.ones(n)
-            galaxy_list['e2_mass'] = -np.ones(n)
-        if 'n_sersic' not in column_names:
-            galaxy_list['n_sersic'] = -np.ones(n)
+        if "vel_disp" not in column_names:
+            galaxy_list["vel_disp"] = -np.ones(n)
+        if "e1_light" not in column_names or "e2_light" not in column_names:
+            galaxy_list["e1_light"] = -np.ones(n)
+            galaxy_list["e2_light"] = -np.ones(n)
+        if "e1_mass" not in column_names or "e2_mass" not in column_names:
+            galaxy_list["e1_mass"] = -np.ones(n)
+            galaxy_list["e2_mass"] = -np.ones(n)
+        if "n_sersic" not in column_names:
+            galaxy_list["n_sersic"] = -np.ones(n)
 
         self._galaxy_select = galaxy_cut(galaxy_list, **kwargs_cut)
         self._num_select = len(self._galaxy_select)
 
-        z_min, z_max = 0, np.max(self._galaxy_select['z'])
+        z_min, z_max = 0, np.max(self._galaxy_select["z"])
         redshift = np.arange(z_min, z_max, 0.1)
-        z_list, vel_disp_list = vel_disp_sdss(sky_area, redshift, vd_min=100, vd_max=500, cosmology=cosmo, noise=True)
+        z_list, vel_disp_list = vel_disp_sdss(
+            sky_area, redshift, vd_min=100, vd_max=500, cosmology=cosmo, noise=True
+        )
         # sort for stellar masses in decreasing manner
-        self._galaxy_select.sort('stellar_mass')
+        self._galaxy_select.sort("stellar_mass")
         self._galaxy_select.reverse()
         # sort velocity dispersion, largest values first
         vel_disp_list = np.flip(np.sort(vel_disp_list))
         num_vel_disp = len(vel_disp_list)
         # abundance match velocity dispersion with elliptical galaxy catalogue
         if num_vel_disp >= self._num_select:
-            self._galaxy_select['vel_disp'] = vel_disp_list[:self._num_select]
+            self._galaxy_select["vel_disp"] = vel_disp_list[: self._num_select]
             # randomly select
         else:
             self._galaxy_select = self._galaxy_select[:num_vel_disp]
-            self._galaxy_select['vel_disp'] = vel_disp_list
+            self._galaxy_select["vel_disp"] = vel_disp_list
             self._num_select = num_vel_disp
 
         # TODO: random reshuffle of matched list
@@ -73,18 +76,20 @@ class EllipticalLensGalaxies(object):
 
         index = random.randint(0, self._num_select - 1)
         deflector = self._galaxy_select[index]
-        if deflector['vel_disp'] == -1:
-            stellar_mass = deflector['stellar_mass']
+        if deflector["vel_disp"] == -1:
+            stellar_mass = deflector["stellar_mass"]
             vel_disp = vel_disp_from_m_star(stellar_mass)
-            deflector['vel_disp'] = vel_disp
-        if deflector['e1_light'] == -1 or deflector['e2_light'] == - 1:
-            e1_light, e2_light, e1_mass, e2_mass = elliptical_projected_eccentricity(**deflector)
-            deflector['e1_light'] = e1_light
-            deflector['e2_light'] = e2_light
-            deflector['e1_mass'] = e1_mass
-            deflector['e2_mass'] = e2_mass
-        if deflector['n_sersic'] == -1:
-            deflector['n_sersic'] = 4  # TODO make a better estimate with scatter
+            deflector["vel_disp"] = vel_disp
+        if deflector["e1_light"] == -1 or deflector["e2_light"] == -1:
+            e1_light, e2_light, e1_mass, e2_mass = elliptical_projected_eccentricity(
+                **deflector
+            )
+            deflector["e1_light"] = e1_light
+            deflector["e2_light"] = e2_light
+            deflector["e1_mass"] = e1_mass
+            deflector["e2_mass"] = e2_mass
+        if deflector["n_sersic"] == -1:
+            deflector["n_sersic"] = 4  # TODO make a better estimate with scatter
         return deflector
 
 
@@ -128,5 +133,5 @@ def vel_disp_from_m_star(m_star):
     :return: the velocity dispersion ("km/s")
 
     """
-    v_disp = (np.power(10, 2.32) * np.power(m_star/1e11, 0.24))
+    v_disp = np.power(10, 2.32) * np.power(m_star / 1e11, 0.24)
     return v_disp

--- a/sim_pipeline/Deflectors/velocity_dispersion.py
+++ b/sim_pipeline/Deflectors/velocity_dispersion.py
@@ -11,8 +11,7 @@ This module provides functions to compute velocity dispersion using schechter fu
 
 
 def vel_disp_sdss(sky_area, redshift, vd_min, vd_max, cosmology, noise=True):
-    """
-    velocity dispersion function in a cone matched by SDSS measurements
+    """Velocity dispersion function in a cone matched by SDSS measurements.
 
     Parameters
     ----------
@@ -53,7 +52,6 @@ def vel_disp_sdss(sky_area, redshift, vd_min, vd_max, cosmology, noise=True):
     References
     ----------
     .. [1] Choi, Park and Vogeley, (2007), astro-ph/0611607, doi:10.1086/511060
-
     """
     # SDSS velocity dispersion function for galaxies brighter than Mr >= -16.8
     phi_star = 8.0 * 10 ** (-3) / cosmology.h**3
@@ -127,7 +125,6 @@ def schechter_vel_disp(
     redshifts, velocity dispersion : tuple of array_like
         Redshifts and velocity dispersion of the galaxy sample described by the Schechter
         velocity dispersion function.
-
     """
 
     # sample halo redshifts
@@ -215,8 +212,6 @@ def schechter_vel_disp_redshift(
     References
     ----------
     .. [1] Choi, Park and Vogeley, (2007), astro-ph/0611607, doi:10.1086/511060
-
-
     """
     alpha_prime = alpha / beta - 1
     x_min, x_max = (vd_min / vd_star) ** beta, (vd_max / vd_star) ** beta
@@ -253,8 +248,8 @@ def schechter_vel_disp_redshift(
 def schechter_velocity_dispersion_function(
     alpha, beta, vd_star, vd_min, vd_max, size=None, resolution=1000
 ):
-    r"""Sample velocity dispersion of elliptical galaxies in the local universe
-    following a Schecter function.
+    r"""Sample velocity dispersion of elliptical galaxies in the local universe following
+    a Schecter function.
 
     Parameters
     ----------
@@ -295,7 +290,6 @@ def schechter_velocity_dispersion_function(
     References
     ----------
     .. [1] Choi, Park and Vogeley, (2007), astro-ph/0611607, doi:10.1086/511060
-
     """
 
     if np.ndim(alpha) > 0:

--- a/sim_pipeline/Deflectors/velocity_dispersion.py
+++ b/sim_pipeline/Deflectors/velocity_dispersion.py
@@ -252,7 +252,7 @@ def schechter_vel_disp_redshift(
 def schechter_velocity_dispersion_function(
     alpha, beta, vd_star, vd_min, vd_max, size=None, resolution=1000
 ):
-    r"""Sample velocity dispersion of elliptical galaxies in the local universe following
+    """Sample velocity dispersion of elliptical galaxies in the local universe following
     a Schecter function.
 
     Parameters

--- a/sim_pipeline/Deflectors/velocity_dispersion.py
+++ b/sim_pipeline/Deflectors/velocity_dispersion.py
@@ -6,7 +6,8 @@ from skypy.utils.random import schechter
 """
 This module provides functions to compute velocity dispersion using schechter function.
 """
-#  TODO: some functionality may directly be imported from skypy, once a version is released
+#  TODO: some functionality may directly be imported from skypy, once a version is
+#  released
 #  from skypy.galaxies.velocity_dispersion import schechter_vdf
 
 
@@ -21,7 +22,8 @@ def vel_disp_sdss(sky_area, redshift, vd_min, vd_max, cosmology, noise=True):
         Input redshift grid on which the Schechter function parameters are
         evaluated. Galaxies are sampled over this redshift range.
     vd_min, vd_max: int
-        Lower and upper bounds of random variable x (velocity dispersion). Samples are drawn uniformly from bounds.
+        Lower and upper bounds of random variable x (velocity dispersion). Samples are
+        drawn uniformly from bounds.
     cosmology : `astropy.cosmology`
         `astropy.cosmology` object to calculate comoving densities.
     noise : bool, optional
@@ -30,13 +32,13 @@ def vel_disp_sdss(sky_area, redshift, vd_min, vd_max, cosmology, noise=True):
     Returns
     -------
     redshifts, velocity dispersion : tuple of array_like
-        Redshifts and velocity dispersion of the galaxy sample described by the Schechter
-        velocity dispersion function.
+        Redshifts and velocity dispersion of the galaxy sample described by the
+        Schechter velocity dispersion function.
 
     Notes
     -----
-    The probability distribution function :math:`p(\sigma)` for velocity dispersion :math:`\sigma`
-    can be described by a Schechter function (see eq. (4) in [1]_)
+    The probability distribution function :math:`p(\sigma)` for velocity dispersion
+    :math:`\sigma` can be described by a Schechter function (see eq. (4) in [1]_)
 
     .. math::
 
@@ -105,7 +107,8 @@ def schechter_vel_disp(
     vd_star: float
         The characteristic velocity dispersion.
     vd_min, vd_max: float
-        Lower and upper bounds of random variable x. Samples are drawn uniformly from bounds.
+        Lower and upper bounds of random variable x. Samples are drawn uniformly from
+        bounds.
     sky_area : `~astropy.units.Quantity`
         Sky area over which galaxies are sampled. Must be in units of solid angle.
     cosmology : `astropy.cosmology`
@@ -123,8 +126,8 @@ def schechter_vel_disp(
     Returns
     -------
     redshifts, velocity dispersion : tuple of array_like
-        Redshifts and velocity dispersion of the galaxy sample described by the Schechter
-        velocity dispersion function.
+        Redshifts and velocity dispersion of the galaxy sample described by the
+        Schechter velocity dispersion function.
     """
 
     # sample halo redshifts
@@ -180,7 +183,8 @@ def schechter_vel_disp_redshift(
     vd_star: float
         The characteristic velocity dispersion.
     vd_min, vd_max: int
-        Lower and upper bounds of random variable x. Samples are drawn uniformly from bounds.
+        Lower and upper bounds of random variable x. Samples are drawn uniformly from
+        bounds.
     sky_area : `~astropy.units.Quantity`
         Sky area over which galaxies are sampled. Must be in units of solid angle.
     cosmology : Cosmology
@@ -195,8 +199,8 @@ def schechter_vel_disp_redshift(
 
     Notes
     -----
-    The probability distribution function :math:`p(\sigma)` for velocity dispersion :math:`\sigma`
-    can be described by a Schechter function (see eq. (4) in [1]_)
+    The probability distribution function :math:`p(\sigma)` for velocity dispersion
+    :math:`\sigma` can be described by a Schechter function (see eq. (4) in [1]_)
 
     .. math::
 
@@ -248,8 +252,8 @@ def schechter_vel_disp_redshift(
 def schechter_velocity_dispersion_function(
     alpha, beta, vd_star, vd_min, vd_max, size=None, resolution=1000
 ):
-    r"""Sample velocity dispersion of elliptical galaxies in the local universe following
-    a Schecter function.
+    r"""Sample velocity dispersion of elliptical galaxies in the local universe
+    following a Schecter function.
 
     Parameters
     ----------
@@ -260,7 +264,8 @@ def schechter_velocity_dispersion_function(
     vd_star: float
         The characteristic velocity dispersion.
     vd_min, vd_max: int
-        Lower and upper bounds of random variable x. Samples are drawn uniformly from bounds.
+        Lower and upper bounds of random variable x. Samples are drawn uniformly from
+        bounds.
     resolution: int
         Resolution of the inverse transform sampling spline. Default is 100.
     size: int
@@ -273,8 +278,8 @@ def schechter_velocity_dispersion_function(
 
     Notes
     -----
-    The probability distribution function :math:`p(\sigma)` for velocity dispersion :math:`\sigma`
-    can be described by a Schechter function (see eq. (4) in [1]_)
+    The probability distribution function :math:`p(\sigma)` for velocity dispersion
+    :math:`\sigma` can be described by a Schechter function (see eq. (4) in [1]_)
 
     .. math::
 

--- a/sim_pipeline/Deflectors/velocity_dispersion.py
+++ b/sim_pipeline/Deflectors/velocity_dispersion.py
@@ -60,12 +60,33 @@ def vel_disp_sdss(sky_area, redshift, vd_min, vd_max, cosmology, noise=True):
     vd_star = 161
     alpha = 2.32
     beta = 2.67
-    return schechter_vel_disp(redshift, phi_star, alpha, beta, vd_star, vd_min, vd_max, sky_area, cosmology,
-                              noise=noise)
+    return schechter_vel_disp(
+        redshift,
+        phi_star,
+        alpha,
+        beta,
+        vd_star,
+        vd_min,
+        vd_max,
+        sky_area,
+        cosmology,
+        noise=noise,
+    )
 
 
-def schechter_vel_disp(redshift, phi_star, alpha, beta, vd_star, vd_min, vd_max, sky_area, cosmology, noise=True):
-    r'''Sample redshifts and stellar masses from a Schechter mass function.
+def schechter_vel_disp(
+    redshift,
+    phi_star,
+    alpha,
+    beta,
+    vd_star,
+    vd_min,
+    vd_max,
+    sky_area,
+    cosmology,
+    noise=True,
+):
+    r"""Sample redshifts and stellar masses from a Schechter mass function.
 
     Sample the redshifts and stellar masses of galaxies following a Schechter
     mass function with potentially redshift-dependent parameters, limited
@@ -107,20 +128,41 @@ def schechter_vel_disp(redshift, phi_star, alpha, beta, vd_star, vd_min, vd_max,
         Redshifts and velocity dispersion of the galaxy sample described by the Schechter
         velocity dispersion function.
 
-    '''
+    """
 
     # sample halo redshifts
-    z = schechter_vel_disp_redshift(redshift, phi_star, alpha, beta, vd_star, vd_min, vd_max,
-                                    sky_area, cosmology, noise)
+    z = schechter_vel_disp_redshift(
+        redshift,
+        phi_star,
+        alpha,
+        beta,
+        vd_star,
+        vd_min,
+        vd_max,
+        sky_area,
+        cosmology,
+        noise,
+    )
     # sample galaxy mass for redshifts
-    vel_disp = schechter_velocity_dispersion_function(alpha, beta, vd_star, vd_min=vd_min,
-                                                        vd_max=vd_max, size=len(z), resolution=100)
+    vel_disp = schechter_velocity_dispersion_function(
+        alpha, beta, vd_star, vd_min=vd_min, vd_max=vd_max, size=len(z), resolution=100
+    )
     return z, vel_disp
 
 
-def schechter_vel_disp_redshift(redshift, phi_star, alpha, beta, vd_star, vd_min, vd_max, sky_area,
-                                cosmology, noise=True):
-    r'''Sample redshifts from Schechter function.
+def schechter_vel_disp_redshift(
+    redshift,
+    phi_star,
+    alpha,
+    beta,
+    vd_star,
+    vd_min,
+    vd_max,
+    sky_area,
+    cosmology,
+    noise=True,
+):
+    r"""Sample redshifts from Schechter function.
 
     Sample the redshifts of velocity dispersion following a Schechter function
     with potentially redshift-dependent parameters, limited by velocity dispersion
@@ -175,7 +217,7 @@ def schechter_vel_disp_redshift(redshift, phi_star, alpha, beta, vd_star, vd_min
     .. [1] Choi, Park and Vogeley, (2007), astro-ph/0611607, doi:10.1086/511060
 
 
-    '''
+    """
     alpha_prime = alpha / beta - 1
     x_min, x_max = (vd_min / vd_star) ** beta, (vd_max / vd_star) ** beta
 
@@ -184,27 +226,33 @@ def schechter_vel_disp_redshift(redshift, phi_star, alpha, beta, vd_star, vd_min
 
     # gamma function integrand
     def f(lnx, a):
-        return np.exp(a*lnx - np.exp(lnx)) if lnx < lnxmax.max() else 0.
+        return np.exp(a * lnx - np.exp(lnx)) if lnx < lnxmax.max() else 0.0
 
     # integrate gamma function for each redshift
 
-    gamma_ab = scipy.special.gamma(alpha/beta)
+    gamma_ab = scipy.special.gamma(alpha / beta)
 
     gam = np.empty_like(redshift)
 
     for i, _ in np.ndenumerate(gam):
-
         gam[i], _ = scipy.integrate.quad(f, lnxmin, lnxmax, args=(alpha_prime,))
 
     # comoving number density is normalisation times upper incomplete gamma
-    density = phi_star*gam / gamma_ab
+    density = phi_star * gam / gamma_ab
 
     # sample redshifts from the comoving density
-    return redshifts_from_comoving_density(redshift=redshift, density=density,
-                                           sky_area=sky_area, cosmology=cosmology, noise=noise)
+    return redshifts_from_comoving_density(
+        redshift=redshift,
+        density=density,
+        sky_area=sky_area,
+        cosmology=cosmology,
+        noise=noise,
+    )
 
 
-def schechter_velocity_dispersion_function(alpha, beta, vd_star, vd_min, vd_max, size=None, resolution=1000):
+def schechter_velocity_dispersion_function(
+    alpha, beta, vd_star, vd_min, vd_max, size=None, resolution=1000
+):
     r"""Sample velocity dispersion of elliptical galaxies in the local universe
     following a Schecter function.
 
@@ -251,12 +299,12 @@ def schechter_velocity_dispersion_function(alpha, beta, vd_star, vd_min, vd_max,
     """
 
     if np.ndim(alpha) > 0:
-        raise NotImplementedError('only scalar alpha is supported')
+        raise NotImplementedError("only scalar alpha is supported")
 
-    alpha_prime = alpha/beta - 1
-    x_min, x_max = (vd_min/vd_star)**beta, (vd_max/vd_star)**beta
+    alpha_prime = alpha / beta - 1
+    x_min, x_max = (vd_min / vd_star) ** beta, (vd_max / vd_star) ** beta
 
     samples = schechter(alpha_prime, x_min, x_max, resolution=resolution, size=size)
-    samples = samples**(1/beta) * vd_star
+    samples = samples ** (1 / beta) * vd_star
 
     return samples

--- a/sim_pipeline/Deflectors/velocity_dispersion.py
+++ b/sim_pipeline/Deflectors/velocity_dispersion.py
@@ -252,8 +252,8 @@ def schechter_vel_disp_redshift(
 def schechter_velocity_dispersion_function(
     alpha, beta, vd_star, vd_min, vd_max, size=None, resolution=1000
 ):
-    r"""Sample velocity dispersion of elliptical galaxies in the local universe
-    following a Schecter function.
+    r"""Sample velocity dispersion of elliptical galaxies in the local universe following
+    a Schecter function.
 
     Parameters
     ----------

--- a/sim_pipeline/Observations/image_quality_lenstronomy.py
+++ b/sim_pipeline/Observations/image_quality_lenstronomy.py
@@ -3,8 +3,7 @@ from lenstronomy.SimulationAPI.ObservationConfig.Roman import Roman
 
 
 def kwargs_single_band(band, observatory="LSST", **kwargs):
-    """
-    This is the function for returning the band information.
+    """This is the function for returning the band information.
 
     :param band: 'u', 'g', 'r', 'i', 'z' or 'y' supported. Determines imaging bands.
     :type band: str

--- a/sim_pipeline/Observations/image_quality_lenstronomy.py
+++ b/sim_pipeline/Observations/image_quality_lenstronomy.py
@@ -2,7 +2,7 @@ from lenstronomy.SimulationAPI.ObservationConfig.LSST import LSST
 from lenstronomy.SimulationAPI.ObservationConfig.Roman import Roman
 
 
-def kwargs_single_band(band, observatory='LSST', **kwargs):
+def kwargs_single_band(band, observatory="LSST", **kwargs):
     """
     This is the function for returning the band information.
 
@@ -15,8 +15,8 @@ def kwargs_single_band(band, observatory='LSST', **kwargs):
     :return: configuration of imaging data
     :rtype: dict
     """
-    if observatory == 'LSST':
+    if observatory == "LSST":
         observatory = LSST(band=band, **kwargs)
-    elif observatory == 'Roman':
+    elif observatory == "Roman":
         observatory = Roman(band=band, **kwargs)
     return observatory.kwargs_single_band()

--- a/sim_pipeline/Observations/roman_speclite.py
+++ b/sim_pipeline/Observations/roman_speclite.py
@@ -1,4 +1,3 @@
-
 # set up Roman filters as they are not in speclite
 import numpy as np
 import csv
@@ -8,8 +7,19 @@ import speclite.filters
 
 import sim_pipeline
 
-_filter_name_list = ['F062', 'F087', 'F106', 'F129', 'F158', 'F184', 'F146', 'F213', 'SNPrism', 'Grism_1stOrder',
-                     'Grism_0thOrder']
+_filter_name_list = [
+    "F062",
+    "F087",
+    "F106",
+    "F129",
+    "F158",
+    "F184",
+    "F146",
+    "F213",
+    "SNPrism",
+    "Grism_1stOrder",
+    "Grism_0thOrder",
+]
 
 
 def filter_names():
@@ -19,8 +29,10 @@ def filter_names():
     """
     path = os.path.dirname(sim_pipeline.__file__)
     module_path, _ = os.path.split(path)
-    save_path = os.path.join(module_path, 'data/Filters/Roman/')
-    _filter_names = [str(save_path+'Roman-' + name + '.ecsv') for name in _filter_name_list]
+    save_path = os.path.join(module_path, "data/Filters/Roman/")
+    _filter_names = [
+        str(save_path + "Roman-" + name + ".ecsv") for name in _filter_name_list
+    ]
     return _filter_names
 
 
@@ -31,22 +43,35 @@ def configure_roman_filters():
     """
     path = os.path.dirname(sim_pipeline.__file__)
     module_path, _ = os.path.split(path)
-    file_name_roman = os.path.join(module_path, 'data/Filters/Roman/Roman_effarea_20201130.csv')  # read the file
-    save_path = os.path.join(module_path, 'data/Filters/Roman/')
+    file_name_roman = os.path.join(
+        module_path, "data/Filters/Roman/Roman_effarea_20201130.csv"
+    )  # read the file
+    save_path = os.path.join(module_path, "data/Filters/Roman/")
 
-    responses = {'F062': [], 'F087': [], 'F106': [], 'F129': [], 'F158': [], 'F184': [], 'F146': [], 'F213': [],
-                 'SNPrism': [], 'Grism_1stOrder': [], 'Grism_0thOrder': []}
+    responses = {
+        "F062": [],
+        "F087": [],
+        "F106": [],
+        "F129": [],
+        "F158": [],
+        "F184": [],
+        "F146": [],
+        "F213": [],
+        "SNPrism": [],
+        "Grism_1stOrder": [],
+        "Grism_0thOrder": [],
+    }
 
-    group_name = 'Roman'
+    group_name = "Roman"
     wave = []
 
     area = (2.4 / 2) ** 2 * np.pi  # Roman mirror diameter is 2.4 meters
     # we need to divide by the area as the throughputs are given in effective area in m^2
 
-    with open(file_name_roman, newline='') as myFile:
+    with open(file_name_roman, newline="") as myFile:
         reader = csv.DictReader(myFile)
         for row in reader:
-            wave.append(float(row['Wave']))
+            wave.append(float(row["Wave"]))
             for name in _filter_name_list:
                 responses[name].append(float(row[name]) / area)
     wave = np.array(wave)
@@ -65,7 +90,9 @@ def configure_roman_filters():
             wavelength = np.append(wavelength, max(wavelength) + 100 * u.Angstrom)
             response = np.append(response, 0)
 
-        speclite_filter = speclite.filters.FilterResponse(wavelength=wavelength,
-                                                          response=response,
-                                                          meta=dict(group_name=group_name, band_name=filter_name))
+        speclite_filter = speclite.filters.FilterResponse(
+            wavelength=wavelength,
+            response=response,
+            meta=dict(group_name=group_name, band_name=filter_name),
+        )
         speclite_filter.save(save_path)

--- a/sim_pipeline/Observations/roman_speclite.py
+++ b/sim_pipeline/Observations/roman_speclite.py
@@ -66,7 +66,8 @@ def configure_roman_filters():
     wave = []
 
     area = (2.4 / 2) ** 2 * np.pi  # Roman mirror diameter is 2.4 meters
-    # we need to divide by the area as the throughputs are given in effective area in m^2
+    # we need to divide by the area as the throughputs are given in effective area
+    # in m^2
 
     with open(file_name_roman, newline="") as myFile:
         reader = csv.DictReader(myFile)

--- a/sim_pipeline/ParamDistributions/gaussian_mixture_model.py
+++ b/sim_pipeline/ParamDistributions/gaussian_mixture_model.py
@@ -7,6 +7,7 @@ class GaussianMixtureModel:
     This class is used to represent a mixture of Gaussian distributions,
     each of which is defined by its mean, standard deviation and weight.
     """
+
     def __init__(self, means=None, stds=None, weights=None):
         """
         The constructor for GaussianMixtureModel class. The default values are the means, standard deviations,
@@ -25,8 +26,9 @@ class GaussianMixtureModel:
             stds = [np.sqrt(0.00283885), np.sqrt(0.01066668), np.sqrt(0.0097978)]
         if weights is None:
             weights = [0.62703102, 0.23732313, 0.13564585]
-        assert len(means) == len(stds) == len(
-            weights), 'Lengths of means, standard deviations, and weights must be equal.'
+        assert (
+            len(means) == len(stds) == len(weights)
+        ), "Lengths of means, standard deviations, and weights must be equal."
         self.means = means
         self.stds = stds
         self.weights = weights
@@ -42,4 +44,9 @@ class GaussianMixtureModel:
         :rtype: np.array
         """
         components = np.random.choice(len(self.means), size=size, p=self.weights)
-        return np.array([np.random.normal(self.means[component], self.stds[component]) for component in components])
+        return np.array(
+            [
+                np.random.normal(self.means[component], self.stds[component])
+                for component in components
+            ]
+        )

--- a/sim_pipeline/ParamDistributions/gaussian_mixture_model.py
+++ b/sim_pipeline/ParamDistributions/gaussian_mixture_model.py
@@ -2,10 +2,10 @@ import numpy as np
 
 
 class GaussianMixtureModel:
-    """
-    A Gaussian Mixture Model (GMM) class.
-    This class is used to represent a mixture of Gaussian distributions,
-    each of which is defined by its mean, standard deviation and weight.
+    """A Gaussian Mixture Model (GMM) class.
+
+    This class is used to represent a mixture of Gaussian distributions, each of which
+    is defined by its mean, standard deviation and weight.
     """
 
     def __init__(self, means=None, stds=None, weights=None):
@@ -34,12 +34,10 @@ class GaussianMixtureModel:
         self.weights = weights
 
     def rvs(self, size):
-        """
-        Generate random variables from the GMM distribution.
+        """Generate random variables from the GMM distribution.
 
         :param size: The number of random variables to generate.
         :type size: int
-
         :return: An array of random variables sampled from the GMM distribution.
         :rtype: np.array
         """

--- a/sim_pipeline/ParamDistributions/gaussian_mixture_model.py
+++ b/sim_pipeline/ParamDistributions/gaussian_mixture_model.py
@@ -10,8 +10,9 @@ class GaussianMixtureModel:
 
     def __init__(self, means=None, stds=None, weights=None):
         """
-        The constructor for GaussianMixtureModel class. The default values are the means, standard deviations,
-        and weights of the fits to the data in the table 2 of https://doi.org/10.1093/mnras/stac2235 and others.
+        The constructor for GaussianMixtureModel class. The default values are the
+        means, standard deviations, and weights of the fits to the data in the table
+        2 of https://doi.org/10.1093/mnras/stac2235 and others.
 
         :param means: the mean values of the Gaussian components.
         :type means: list of float

--- a/sim_pipeline/Pipelines/skypy_pipeline.py
+++ b/sim_pipeline/Pipelines/skypy_pipeline.py
@@ -8,6 +8,7 @@ class SkyPyPipeline:
     """
     Class for skypy configuration.
     """
+
     def __init__(self, skypy_config=None, sky_area=None, filters=None):
         """
         :param skypy_config: path to SkyPy configuration yaml file. If None, uses 'data/SkyPy/lsst-like.yml'.
@@ -20,13 +21,13 @@ class SkyPyPipeline:
         path = os.path.dirname(sim_pipeline.__file__)
         module_path, _ = os.path.split(path)
         if skypy_config is None:
-            skypy_config = os.path.join(module_path, 'data/SkyPy/lsst-like.yml')
+            skypy_config = os.path.join(module_path, "data/SkyPy/lsst-like.yml")
 
         if sky_area is None and filters is None:
             self._pipeline = Pipeline.read(skypy_config)
             self._pipeline.execute()
         else:
-            with open(skypy_config, 'r') as file:
+            with open(skypy_config, "r") as file:
                 content = file.read()
 
             if sky_area is not None:
@@ -34,7 +35,9 @@ class SkyPyPipeline:
                 new_fsky = f"fsky: {sky_area.value} {sky_area.unit}"
                 content = content.replace(old_fsky, new_fsky)
 
-            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.yml') as tmp_file:
+            with tempfile.NamedTemporaryFile(
+                mode="w", delete=False, suffix=".yml"
+            ) as tmp_file:
                 tmp_file.write(content)
 
             self._pipeline = Pipeline.read(tmp_file.name)
@@ -42,7 +45,7 @@ class SkyPyPipeline:
 
             # Remove the temporary file after the pipeline has been executed
             os.remove(tmp_file.name)
-        #TODO: note that the f_sky can not be set to large. Need to figure out how to do this properly
+        # TODO: note that the f_sky can not be set to large. Need to figure out how to do this properly
         # for LSST simulations (10^5 deg^2)
 
     @property
@@ -53,7 +56,7 @@ class SkyPyPipeline:
         :return: list of blue galaxies
         :rtype: list of dict
         """
-        return self._pipeline['blue']
+        return self._pipeline["blue"]
 
     @property
     def red_galaxies(self):
@@ -63,4 +66,4 @@ class SkyPyPipeline:
         :return: list of red galaxies
         :rtype: list of dict
         """
-        return self._pipeline['red']
+        return self._pipeline["red"]

--- a/sim_pipeline/Pipelines/skypy_pipeline.py
+++ b/sim_pipeline/Pipelines/skypy_pipeline.py
@@ -5,9 +5,7 @@ import tempfile
 
 
 class SkyPyPipeline:
-    """
-    Class for skypy configuration.
-    """
+    """Class for skypy configuration."""
 
     def __init__(self, skypy_config=None, sky_area=None, filters=None):
         """
@@ -50,8 +48,7 @@ class SkyPyPipeline:
 
     @property
     def blue_galaxies(self):
-        """
-        skypy pipeline for blue galaxies
+        """Skypy pipeline for blue galaxies.
 
         :return: list of blue galaxies
         :rtype: list of dict
@@ -60,8 +57,7 @@ class SkyPyPipeline:
 
     @property
     def red_galaxies(self):
-        """
-        skypy pipeline for red galaxies
+        """Skypy pipeline for red galaxies.
 
         :return: list of red galaxies
         :rtype: list of dict

--- a/sim_pipeline/Pipelines/skypy_pipeline.py
+++ b/sim_pipeline/Pipelines/skypy_pipeline.py
@@ -9,10 +9,12 @@ class SkyPyPipeline:
 
     def __init__(self, skypy_config=None, sky_area=None, filters=None):
         """
-        :param skypy_config: path to SkyPy configuration yaml file. If None, uses 'data/SkyPy/lsst-like.yml'.
+        :param skypy_config: path to SkyPy configuration yaml file. If None, uses
+            'data/SkyPy/lsst-like.yml'.
         :type skypy_config: string or None
         :type sky_area: `~astropy.units.Quantity`
-        :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid angle.
+        :param sky_area: Sky area over which galaxies are sampled. Must be in units of
+            solid angle.
         :param filters: filters for SED integration
         :type filters: list of strings or None
         """
@@ -43,7 +45,8 @@ class SkyPyPipeline:
 
             # Remove the temporary file after the pipeline has been executed
             os.remove(tmp_file.name)
-        # TODO: note that the f_sky can not be set to large. Need to figure out how to do this properly
+        # TODO: note that the f_sky can not be set to large. Need to figure out
+        #  how to do this properly
         # for LSST simulations (10^5 deg^2)
 
     @property

--- a/sim_pipeline/Plots/galaxy_galaxy_plots.py
+++ b/sim_pipeline/Plots/galaxy_galaxy_plots.py
@@ -4,10 +4,8 @@ from sim_pipeline.image_simulation import simulate_image
 
 
 class GalaxyGalaxyLensingPlots(object):
-    """
-    A class to create and display simulated gravitational lensing images using the provided configurations for the
-    source (blue) and lens (red) galaxies.
-    """
+    """A class to create and display simulated gravitational lensing images using the
+    provided configurations for the source (blue) and lens (red) galaxies."""
 
     def __init__(self, lens_pop, num_pix=64, observatory="LSST", **kwargs):
         """
@@ -29,12 +27,14 @@ class GalaxyGalaxyLensingPlots(object):
         self._kwargs = kwargs
 
     def rgb_image(self, lens_class, rgb_band_list, add_noise=True):
-        """
-        Method to generate a rgb-image with lupton_rgb color scale
+        """Method to generate a rgb-image with lupton_rgb color scale.
 
-        :param lens_class: class object containing all information of the lensing system (e.g., GalaxyGalaxyLens())
-        :param rgb_band_list: list of imaging band names corresponding to r-g-b color map
-        :param add_noise: boolean flag, set to True to add noise to the image, default is True
+        :param lens_class: class object containing all information of the lensing system
+            (e.g., GalaxyGalaxyLens())
+        :param rgb_band_list: list of imaging band names corresponding to r-g-b color
+            map
+        :param add_noise: boolean flag, set to True to add noise to the image, default
+            is True
         """
         image_r = simulate_image(
             lens_class=lens_class,
@@ -71,14 +71,17 @@ class GalaxyGalaxyLensingPlots(object):
         n_vertical=1,
         kwargs_lens_cut=None,
     ):
-        """
-        Method to generate and display a grid of simulated gravitational lensing images with or without noise.
+        """Method to generate and display a grid of simulated gravitational lensing
+        images with or without noise.
 
-        :param rgb_band_list: list of imaging band names corresponding to r-g-b color map
-        :param add_noise: boolean flag, set to True to add noise to the images, default is True
+        :param rgb_band_list: list of imaging band names corresponding to r-g-b color
+            map
+        :param add_noise: boolean flag, set to True to add noise to the images, default
+            is True
         :param n_horizont: number of images to display horizontally, default is 1
         :param n_vertical: number of images to display vertically, default is 1
-        :param kwargs_lens_cut: lens selection cuts for GalaxyGalaxyLens.validity_test() function
+        :param kwargs_lens_cut: lens selection cuts for GalaxyGalaxyLens.validity_test()
+            function
         """
         if kwargs_lens_cut is None:
             kwargs_lens_cut = {}

--- a/sim_pipeline/Plots/galaxy_galaxy_plots.py
+++ b/sim_pipeline/Plots/galaxy_galaxy_plots.py
@@ -16,9 +16,9 @@ class GalaxyGalaxyLensingPlots(object):
         :type num_pix: int
         :param observatory: observatory chosen
         :type observatory: str
-        :param kwargs: additional keyword arguments for the bands. Eg: coadd_years (=10): this is
-         the number of years corresponding to num_exposures in obs dict. Currently
-         supported: 1-10.
+        :param kwargs: additional keyword arguments for the bands. Eg: coadd_years
+            (=10): this is the number of years corresponding to num_exposures in obs
+            dict. Currently supported: 1-10.
         :type kwargs: dict
         """
         self._lens_pop = lens_pop

--- a/sim_pipeline/Plots/galaxy_galaxy_plots.py
+++ b/sim_pipeline/Plots/galaxy_galaxy_plots.py
@@ -2,12 +2,14 @@ import matplotlib.pyplot as plt
 from astropy.visualization import make_lupton_rgb
 from sim_pipeline.image_simulation import simulate_image
 
+
 class GalaxyGalaxyLensingPlots(object):
     """
     A class to create and display simulated gravitational lensing images using the provided configurations for the
     source (blue) and lens (red) galaxies.
     """
-    def __init__(self, lens_pop, num_pix=64, observatory='LSST', **kwargs):
+
+    def __init__(self, lens_pop, num_pix=64, observatory="LSST", **kwargs):
         """
 
         :param lens_pop: lens population class
@@ -17,7 +19,7 @@ class GalaxyGalaxyLensingPlots(object):
         :param observatory: observatory chosen
         :type observatory: str
         :param kwargs: additional keyword arguments for the bands. Eg: coadd_years (=10): this is
-         the number of years corresponding to num_exposures in obs dict. Currently 
+         the number of years corresponding to num_exposures in obs dict. Currently
          supported: 1-10.
         :type kwargs: dict
         """
@@ -34,16 +36,41 @@ class GalaxyGalaxyLensingPlots(object):
         :param rgb_band_list: list of imaging band names corresponding to r-g-b color map
         :param add_noise: boolean flag, set to True to add noise to the image, default is True
         """
-        image_r = simulate_image(lens_class=lens_class, band=rgb_band_list[0], num_pix=self.num_pix,
-                                 add_noise=add_noise, observatory=self._observatory, **self._kwargs)
-        image_g = simulate_image(lens_class=lens_class, band=rgb_band_list[1], num_pix=self.num_pix,
-                                 add_noise=add_noise, observatory=self._observatory, **self._kwargs)
-        image_b = simulate_image(lens_class=lens_class, band=rgb_band_list[2], num_pix=self.num_pix,
-                                 add_noise=add_noise, observatory=self._observatory, **self._kwargs)
+        image_r = simulate_image(
+            lens_class=lens_class,
+            band=rgb_band_list[0],
+            num_pix=self.num_pix,
+            add_noise=add_noise,
+            observatory=self._observatory,
+            **self._kwargs
+        )
+        image_g = simulate_image(
+            lens_class=lens_class,
+            band=rgb_band_list[1],
+            num_pix=self.num_pix,
+            add_noise=add_noise,
+            observatory=self._observatory,
+            **self._kwargs
+        )
+        image_b = simulate_image(
+            lens_class=lens_class,
+            band=rgb_band_list[2],
+            num_pix=self.num_pix,
+            add_noise=add_noise,
+            observatory=self._observatory,
+            **self._kwargs
+        )
         image_rgb = make_lupton_rgb(image_r, image_g, image_b, stretch=0.5)
         return image_rgb
 
-    def plot_montage(self, rgb_band_list, add_noise=True, n_horizont=1, n_vertical=1, kwargs_lens_cut=None):
+    def plot_montage(
+        self,
+        rgb_band_list,
+        add_noise=True,
+        n_horizont=1,
+        n_vertical=1,
+        kwargs_lens_cut=None,
+    ):
         """
         Method to generate and display a grid of simulated gravitational lensing images with or without noise.
 
@@ -55,17 +82,23 @@ class GalaxyGalaxyLensingPlots(object):
         """
         if kwargs_lens_cut is None:
             kwargs_lens_cut = {}
-        fig, axes = plt.subplots(n_vertical, n_horizont, figsize=(n_horizont * 3, n_vertical * 3))
+        fig, axes = plt.subplots(
+            n_vertical, n_horizont, figsize=(n_horizont * 3, n_vertical * 3)
+        )
         for i in range(n_horizont):
             for j in range(n_vertical):
                 ax = axes[j, i]
                 lens_class = self._lens_pop.select_lens_at_random(**kwargs_lens_cut)
-                image_rgb = self.rgb_image(lens_class, rgb_band_list, add_noise=add_noise)
-                ax.imshow(image_rgb, aspect='equal', origin='lower')
+                image_rgb = self.rgb_image(
+                    lens_class, rgb_band_list, add_noise=add_noise
+                )
+                ax.imshow(image_rgb, aspect="equal", origin="lower")
                 ax.get_xaxis().set_visible(False)
                 ax.get_yaxis().set_visible(False)
                 ax.autoscale(False)
 
         fig.tight_layout()
-        fig.subplots_adjust(left=None, bottom=None, right=None, top=None, wspace=0., hspace=0.05)
+        fig.subplots_adjust(
+            left=None, bottom=None, right=None, top=None, wspace=0.0, hspace=0.05
+        )
         return fig, axes

--- a/sim_pipeline/Sources/galaxies.py
+++ b/sim_pipeline/Sources/galaxies.py
@@ -6,9 +6,7 @@ from sim_pipeline.Sources.source_base import SourceBase
 
 
 class Galaxies(SourceBase):
-    """
-    class describing elliptical galaxies
-    """
+    """Class describing elliptical galaxies."""
 
     def __init__(self, galaxy_list, kwargs_cut, cosmo, sky_area):
         """
@@ -38,8 +36,7 @@ class Galaxies(SourceBase):
         super(Galaxies, self).__init__(cosmo=cosmo, sky_area=sky_area)
 
     def source_number(self):
-        """
-        number of sources registered (within given area on the sky)
+        """Number of sources registered (within given area on the sky)
 
         :return: number of sources
         """
@@ -47,8 +44,7 @@ class Galaxies(SourceBase):
         return number
 
     def draw_source(self):
-        """
-        Choose source at random.
+        """Choose source at random.
 
         :return: dictionary of source
         """
@@ -66,8 +62,8 @@ class Galaxies(SourceBase):
 
 
 def galaxy_projected_eccentricity(ellipticity):
-    """
-    Projected eccentricity of elliptical galaxies as a function of other deflector parameters
+    """Projected eccentricity of elliptical galaxies as a function of other deflector
+    parameters.
 
     :param ellipticity: eccentricity amplitude
     :type ellipticity: float [0,1)

--- a/sim_pipeline/Sources/galaxies.py
+++ b/sim_pipeline/Sources/galaxies.py
@@ -9,6 +9,7 @@ class Galaxies(SourceBase):
     """
     class describing elliptical galaxies
     """
+
     def __init__(self, galaxy_list, kwargs_cut, cosmo, sky_area):
         """
 
@@ -23,13 +24,13 @@ class Galaxies(SourceBase):
         self.n = len(galaxy_list)
         # add missing keywords in astropy.Table object
         column_names = galaxy_list.colnames
-        if 'ellipticity' not in column_names:
-            raise ValueError('required parameters missing in galaxy_list columns')
-        if 'e1' not in column_names or 'e2' not in column_names:
-            galaxy_list['e1'] = -np.ones(self.n)
-            galaxy_list['e2'] = -np.ones(self.n)
-        if 'n_sersic' not in column_names:
-            galaxy_list['n_sersic'] = -np.ones(self.n)
+        if "ellipticity" not in column_names:
+            raise ValueError("required parameters missing in galaxy_list columns")
+        if "e1" not in column_names or "e2" not in column_names:
+            galaxy_list["e1"] = -np.ones(self.n)
+            galaxy_list["e2"] = -np.ones(self.n)
+        if "n_sersic" not in column_names:
+            galaxy_list["n_sersic"] = -np.ones(self.n)
         # make cuts
         self._galaxy_select = galaxy_cut(galaxy_list, **kwargs_cut)
 
@@ -55,12 +56,12 @@ class Galaxies(SourceBase):
         index = random.randint(0, self._num_select - 1)
         galaxy = self._galaxy_select[index]
 
-        if galaxy['e1'] == -1 or galaxy['e2'] == -1:
-            e1, e2 = galaxy_projected_eccentricity(float(galaxy['ellipticity']))
-            galaxy['e1'] = e1
-            galaxy['e2'] = e2
-        if galaxy['n_sersic'] == -1:
-            galaxy['n_sersic'] = 1  # TODO make a better estimate with scatter
+        if galaxy["e1"] == -1 or galaxy["e2"] == -1:
+            e1, e2 = galaxy_projected_eccentricity(float(galaxy["ellipticity"]))
+            galaxy["e1"] = e1
+            galaxy["e2"] = e2
+        if galaxy["n_sersic"] == -1:
+            galaxy["n_sersic"] = 1  # TODO make a better estimate with scatter
         return galaxy
 
 

--- a/sim_pipeline/Sources/galaxies.py
+++ b/sim_pipeline/Sources/galaxies.py
@@ -16,7 +16,8 @@ class Galaxies(SourceBase):
         :param kwargs_cut: cuts in parameters
         :type kwargs_cut: dict
         :param cosmo: astropy.cosmology instance
-        :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid angle.
+        :param sky_area: Sky area over which galaxies are sampled. Must be in units of
+            solid angle.
         :type sky_area: `~astropy.units.Quantity`
         """
         self.n = len(galaxy_list)

--- a/sim_pipeline/Sources/quasars.py
+++ b/sim_pipeline/Sources/quasars.py
@@ -6,6 +6,7 @@ class Quasars(SourceBase):
     Class to describe quasars as sources.
 
     """
+
     def __init__(self, cosmo, sky_area):
         """
 

--- a/sim_pipeline/Sources/quasars.py
+++ b/sim_pipeline/Sources/quasars.py
@@ -9,7 +9,8 @@ class Quasars(SourceBase):
 
         :param cosmo: cosmology
         :type cosmo: ~astropy.cosmology class
-        :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid angle.
+        :param sky_area: Sky area over which galaxies are sampled. Must be in units of
+            solid angle.
         :type sky_area: `~astropy.units.Quantity`
         """
         super(Quasars, self).__init__(cosmo=cosmo, sky_area=sky_area)

--- a/sim_pipeline/Sources/quasars.py
+++ b/sim_pipeline/Sources/quasars.py
@@ -2,10 +2,7 @@ from sim_pipeline.Sources.source_base import SourceBase
 
 
 class Quasars(SourceBase):
-    """
-    Class to describe quasars as sources.
-
-    """
+    """Class to describe quasars as sources."""
 
     def __init__(self, cosmo, sky_area):
         """

--- a/sim_pipeline/Sources/source_base.py
+++ b/sim_pipeline/Sources/source_base.py
@@ -1,9 +1,8 @@
-
-
 class SourceBase(object):
     """
     Base class with functions all source classes must have to be able to render populations
     """
+
     def __init__(self, cosmo, sky_area):
         """
 
@@ -21,7 +20,9 @@ class SourceBase(object):
 
         :return: number of sources
         """
-        raise NotImplementedError('Function source_number not implemented in chosen source class.')
+        raise NotImplementedError(
+            "Function source_number not implemented in chosen source class."
+        )
 
     def draw_source(self):
         """
@@ -29,4 +30,6 @@ class SourceBase(object):
 
         :return: dictionary of source
         """
-        raise NotImplementedError('Function draw_source not implemented in chosen source class.')
+        raise NotImplementedError(
+            "Function draw_source not implemented in chosen source class."
+        )

--- a/sim_pipeline/Sources/source_base.py
+++ b/sim_pipeline/Sources/source_base.py
@@ -1,7 +1,6 @@
 class SourceBase(object):
-    """
-    Base class with functions all source classes must have to be able to render populations
-    """
+    """Base class with functions all source classes must have to be able to render
+    populations."""
 
     def __init__(self, cosmo, sky_area):
         """
@@ -15,8 +14,7 @@ class SourceBase(object):
         self._sky_area = sky_area
 
     def source_number(self):
-        """
-        Number of sources registered (within given area on the sky)
+        """Number of sources registered (within given area on the sky)
 
         :return: number of sources
         """
@@ -25,8 +23,7 @@ class SourceBase(object):
         )
 
     def draw_source(self):
-        """
-        Choose source at random.
+        """Choose source at random.
 
         :return: dictionary of source
         """

--- a/sim_pipeline/Sources/source_base.py
+++ b/sim_pipeline/Sources/source_base.py
@@ -7,7 +7,8 @@ class SourceBase(object):
 
         :param cosmo: cosmology
         :type cosmo: ~astropy.cosmology class
-        :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid angle.
+        :param sky_area: Sky area over which galaxies are sampled. Must be in units of
+            solid angle.
         :type sky_area: `~astropy.units.Quantity`
         """
         self._cosmo = cosmo

--- a/sim_pipeline/Util/param_util.py
+++ b/sim_pipeline/Util/param_util.py
@@ -2,8 +2,7 @@ import numpy as np
 
 
 def epsilon2e(epsilon):
-    """
-    Translates ellipticity definitions from
+    """Translates ellipticity definitions from.
 
     .. math::
         epsilon = \\equic \\frac{1 - q^2}{1 + q^2}
@@ -25,9 +24,7 @@ def epsilon2e(epsilon):
 
 
 def e2epsilon(e):
-    """
-
-    translates ellipticity definitions from
+    """Translates ellipticity definitions from.
 
     .. math::
         e = \\equic \\frac{1 - q}{1 + q}
@@ -44,8 +41,7 @@ def e2epsilon(e):
 
 
 def random_ra_dec(ra_min, ra_max, dec_min, dec_max, n):
-    """
-    Generates n number of random ra, dec pair with in a given limits.
+    """Generates n number of random ra, dec pair with in a given limits.
 
     :param ra_min: minimum limit for ra
     :param ra_max: maximum limit for ra

--- a/sim_pipeline/Util/param_util.py
+++ b/sim_pipeline/Util/param_util.py
@@ -46,7 +46,7 @@ def e2epsilon(e):
 def random_ra_dec(ra_min, ra_max, dec_min, dec_max, n):
     """
     Generates n number of random ra, dec pair with in a given limits.
-    
+
     :param ra_min: minimum limit for ra
     :param ra_max: maximum limit for ra
     :param dec_min: minimum limit for dec
@@ -54,6 +54,6 @@ def random_ra_dec(ra_min, ra_max, dec_min, dec_max, n):
     :param n: number of random sample
     :returns: n number of ra, dec pair within given limits
     """
-    ra=np.random.uniform(ra_min,ra_max, n)
-    dec=np.random.uniform(dec_min, dec_max, n)
+    ra = np.random.uniform(ra_min, ra_max, n)
+    dec = np.random.uniform(dec_min, dec_max, n)
     return ra, dec

--- a/sim_pipeline/__init__.py
+++ b/sim_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """Top-level package for sim-pipeline."""
 
 __author__ = """DESC/SLSC"""
-__version__ = '0.1.0'
+__version__ = "0.1.0"

--- a/sim_pipeline/galaxy_galaxy_lens.py
+++ b/sim_pipeline/galaxy_galaxy_lens.py
@@ -9,9 +9,7 @@ from lenstronomy.Util import util, data_util
 
 
 class GalaxyGalaxyLens(object):
-    """
-    class to manage individual galaxy-galaxy lenses
-    """
+    """Class to manage individual galaxy-galaxy lenses."""
 
     def __init__(
         self,
@@ -63,8 +61,7 @@ class GalaxyGalaxyLens(object):
 
     @property
     def lens_position(self):
-        """
-        center of the deflector position
+        """Center of the deflector position.
 
         :return: [x_pox, y_pos] in arc seconds
         """
@@ -77,9 +74,9 @@ class GalaxyGalaxyLens(object):
 
     @property
     def source_position(self):
-        """
-        source position, either the center of the extended source or the point source. If not present from the catalog,
-        it is drawn uniformly within the circle of the test area centered on the lens
+        """Source position, either the center of the extended source or the point
+        source. If not present from the catalog, it is drawn uniformly within the circle
+        of the test area centered on the lens.
 
         :return: [x_pos, y_pos]
         """
@@ -98,9 +95,9 @@ class GalaxyGalaxyLens(object):
         return self._center_source
 
     def image_positions(self):
-        """
-        Return image positions by solving the lens equation. These are either the centers of the extended source, or
-        the point sources in case of (added) point-like sources, such as quasars or SNe.
+        """Return image positions by solving the lens equation. These are either the
+        centers of the extended source, or the point sources in case of (added) point-
+        like sources, such as quasars or SNe.
 
         :return: x-pos, y-pos
         """
@@ -126,12 +123,13 @@ class GalaxyGalaxyLens(object):
     def validity_test(
         self, min_image_separation=0, max_image_separation=10, mag_arc_limit=None
     ):
-        """
-        check whether lensing configuration matches selection and plausibility criteria
+        """Check whether lensing configuration matches selection and plausibility
+        criteria.
 
         :param min_image_separation: minimum image separation
         :param max_image_separation: maximum image separation
-        :param mag_arc_limit: dictionary with key of bands and values of magnitude limits of integrated lensed arc
+        :param mag_arc_limit: dictionary with key of bands and values of magnitude
+            limits of integrated lensed arc
         :type mag_arc_limit: dict with key of bands and values of magnitude limits
         :return: boolean
         """
@@ -203,8 +201,7 @@ class GalaxyGalaxyLens(object):
 
     @property
     def einstein_radius(self):
-        """
-        Einstein radius, including the SIS + external convergence effect
+        """Einstein radius, including the SIS + external convergence effect.
 
         :return: Einstein radius [arc seconds]
         """
@@ -239,8 +236,7 @@ class GalaxyGalaxyLens(object):
         return self._lens_dict["vel_disp"]
 
     def los_linear_distortions(self):
-        """
-        line-of-sight distortions in shear and convergence
+        """Line-of-sight distortions in shear and convergence.
 
         :return: kappa, gamma1, gamma2
         """
@@ -265,8 +261,7 @@ class GalaxyGalaxyLens(object):
         return self._gamma[0], self._gamma[1], self._kappa
 
     def deflector_magnitude(self, band):
-        """
-        apparent magnitude of the deflector for a given band
+        """Apparent magnitude of the deflector for a given band.
 
         :param band: imaging band
         :type band: string
@@ -276,8 +271,8 @@ class GalaxyGalaxyLens(object):
         return self._lens_dict[band_string]
 
     def point_source_magnitude(self, band, lensed=False):
-        """
-        point source magnitude, either unlensed (single value) or lensed (array) with macro-model magnifications
+        """Point source magnitude, either unlensed (single value) or lensed (array) with
+        macro-model magnifications.
 
         # TODO: time-variability with time-delayed and micro-lensing
 
@@ -296,9 +291,8 @@ class GalaxyGalaxyLens(object):
         return source_mag
 
     def extended_source_magnitude(self, band, lensed=False):
-        """
-        unlensed apparent magnitude of the extended source for a given band
-        (assumes that size is the same for different bands)
+        """Unlensed apparent magnitude of the extended source for a given band (assumes
+        that size is the same for different bands)
 
         :param band: imaging band
         :type band: string
@@ -315,8 +309,7 @@ class GalaxyGalaxyLens(object):
         return source_mag
 
     def point_source_magnification(self):
-        """
-        macro-model magnification of point sources
+        """Macro-model magnification of point sources.
 
         :return: signed magnification of point sources in same order as image positions
         """
@@ -328,9 +321,8 @@ class GalaxyGalaxyLens(object):
         return self._ps_magnification
 
     def host_magnification(self):
-        """
-        compute the extended lensed surface brightness and calculates the integrated flux-weighted magnification factor
-        of the extended host galaxy
+        """Compute the extended lensed surface brightness and calculates the integrated
+        flux-weighted magnification factor of the extended host galaxy.
 
         :return: integrated magnification factor of host magnitude
         """
@@ -450,8 +442,7 @@ class GalaxyGalaxyLens(object):
         return kwargs_model, kwargs_params
 
     def lens_model_lenstronomy(self):
-        """
-        returns lens model instance and parameters in lenstronomy conventions
+        """Returns lens model instance and parameters in lenstronomy conventions.
 
         :return: lens_model_list, kwargs_lens
         """
@@ -476,9 +467,9 @@ class GalaxyGalaxyLens(object):
 
 
 def image_separation_from_positions(image_positions):
-    """
-    calculate image separation in arc-seconds; if there are only two images, the separation between them is returned;
-    if there are more than 2 images, the maximum separation is returned
+    """Calculate image separation in arc-seconds; if there are only two images, the
+    separation between them is returned; if there are more than 2 images, the maximum
+    separation is returned.
 
     :param image_positions: list of image positions in arc-seconds
     :return: image separation in arc-seconds
@@ -498,8 +489,7 @@ def image_separation_from_positions(image_positions):
 
 
 def theta_e_when_source_infinity(deflector_dict=None, v_sigma=None):
-    """
-    calculate Einstein radius in arc-seconds for a source at infinity
+    """Calculate Einstein radius in arc-seconds for a source at infinity.
 
     :param deflector_dict: deflector properties
     :param v_sigma: velocity dispersion in km/s

--- a/sim_pipeline/galaxy_galaxy_lens.py
+++ b/sim_pipeline/galaxy_galaxy_lens.py
@@ -31,7 +31,8 @@ class GalaxyGalaxyLens(object):
         :param cosmo: astropy.cosmology instance
         :param source_type: type of the source 'extended' or 'point_source' supported
         :type source_type: str
-        :param test_area: area of disk around one lensing galaxies to be investigated on (in arc-seconds^2)
+        :param test_area: area of disk around one lensing galaxies to be investigated
+            on (in arc-seconds^2)
         :param mixgauss_weights: weights of the Gaussian mixture
         :param mixgauss_stds: standard deviations of the Gaussian mixture
         :param mixgauss_means: means of the Gaussian mixture
@@ -109,7 +110,8 @@ class GalaxyGalaxyLens(object):
             source_pos_x, source_pos_y = self.source_position
 
             kwargs_lens = kwargs_params["kwargs_lens"]
-            # TODO: analytical solver possible but currently does not support the convergence term
+            # TODO: analytical solver possible but currently does not support the
+            #  convergence term
             self._image_positions = lens_eq_solver.image_position_from_source(
                 source_pos_x,
                 source_pos_y,
@@ -133,20 +135,23 @@ class GalaxyGalaxyLens(object):
         :type mag_arc_limit: dict with key of bands and values of magnitude limits
         :return: boolean
         """
-        # Criteria 1:The redshift of the lens (z_lens) must be less than the redshift of the source (z_source).
+        # Criteria 1:The redshift of the lens (z_lens) must be less than the redshift of
+        # the source (z_source).
         z_lens = self._lens_dict["z"]
         z_source = self._source_dict["z"]
         if z_lens >= z_source:
             return False
 
-        # Criteria 2: The angular Einstein radius of the lensing configuration (theta_E) times 2 must be greater than
-        # or equal to the minimum image separation (min_image_separation) and less than or equal to the maximum image
+        # Criteria 2: The angular Einstein radius of the lensing configuration (theta_E)
+        # times 2 must be greater than or equal to the minimum image separation
+        # (min_image_separation) and less than or equal to the maximum image
         # separation (max_image_separation).
         if not min_image_separation <= 2 * self._theta_E_sis <= max_image_separation:
             return False
 
-        # Criteria 3: The distance between the lens center and the source position must be less than or equal to the
-        # angular Einstein radius of the lensing configuration (times sqrt(2)).
+        # Criteria 3: The distance between the lens center and the source position must
+        # be less than or equal to the angular Einstein radius of the lensing
+        # configuration (times sqrt(2)).
         center_lens, center_source = self.lens_position, self.source_position
 
         if np.sum((center_lens - center_source) ** 2) > self._theta_E_sis**2 * 2:
@@ -157,15 +162,16 @@ class GalaxyGalaxyLens(object):
         if len(image_positions[0]) < 2:
             return False
 
-        # Criteria 5: The maximum separation between any two image positions must be greater than or equal to the
-        # minimum image separation and less than or equal to the maximum image separation.
+        # Criteria 5: The maximum separation between any two image positions must be
+        # greater than or equal to the minimum image separation and less than or
+        # equal to the maximum image separation.
         image_separation = image_separation_from_positions(image_positions)
         if not min_image_separation <= image_separation <= max_image_separation:
             return False
 
         # Criteria 6: (optional)
-        # compute the magnified brightness of the lensed extended arc for different bands
-        # at least in one band, the magnitude has to be brighter than the limit
+        # compute the magnified brightness of the lensed extended arc for different
+        # bands at least in one band, the magnitude has to be brighter than the limit
         if mag_arc_limit is not None:
             bool_mag_limit = False
             host_mag = self.host_magnification()

--- a/sim_pipeline/galaxy_galaxy_lens.py
+++ b/sim_pipeline/galaxy_galaxy_lens.py
@@ -13,10 +13,17 @@ class GalaxyGalaxyLens(object):
     class to manage individual galaxy-galaxy lenses
     """
 
-    def __init__(self, source_dict, deflector_dict, cosmo,
-                 source_type='extended',
-                 test_area=4*np.pi,
-                 mixgauss_means=None, mixgauss_stds=None, mixgauss_weights=None):
+    def __init__(
+        self,
+        source_dict,
+        deflector_dict,
+        cosmo,
+        source_type="extended",
+        test_area=4 * np.pi,
+        mixgauss_means=None,
+        mixgauss_stds=None,
+        mixgauss_weights=None,
+    ):
         """
 
         :param source_dict: source properties
@@ -42,12 +49,17 @@ class GalaxyGalaxyLens(object):
         self._mixgauss_means = mixgauss_means
         self._mixgauss_stds = mixgauss_stds
         self._mixgauss_weights = mixgauss_weights
-        if self._lens_dict['z'] >= self._source_dict['z']:
+        if self._lens_dict["z"] >= self._source_dict["z"]:
             self._theta_E_sis = 0
         else:
-            lens_cosmo = LensCosmo(z_lens=float(self._lens_dict['z']), z_source=float(self._source_dict['z']),
-                                   cosmo=self.cosmo)
-            self._theta_E_sis = lens_cosmo.sis_sigma_v2theta_E(float(self._lens_dict['vel_disp']))
+            lens_cosmo = LensCosmo(
+                z_lens=float(self._lens_dict["z"]),
+                z_source=float(self._source_dict["z"]),
+                cosmo=self.cosmo,
+            )
+            self._theta_E_sis = lens_cosmo.sis_sigma_v2theta_E(
+                float(self._lens_dict["vel_disp"])
+            )
 
     @property
     def lens_position(self):
@@ -56,8 +68,10 @@ class GalaxyGalaxyLens(object):
 
         :return: [x_pox, y_pos] in arc seconds
         """
-        if not hasattr(self, '_center_lens'):
-            center_x_lens, center_y_lens = np.random.normal(loc=0, scale=0.1), np.random.normal(loc=0, scale=0.1)
+        if not hasattr(self, "_center_lens"):
+            center_x_lens, center_y_lens = np.random.normal(
+                loc=0, scale=0.1
+            ), np.random.normal(loc=0, scale=0.1)
             self._center_lens = np.array([center_x_lens, center_y_lens])
         return self._center_lens
 
@@ -71,7 +85,7 @@ class GalaxyGalaxyLens(object):
         """
         center_lens = self.lens_position
 
-        if not hasattr(self, '_center_source'):
+        if not hasattr(self, "_center_source"):
             # Define the radius of the test area circle
             test_area_radius = np.sqrt(self.test_area / np.pi)
             # Randomly generate a radius within the test area circle
@@ -90,23 +104,28 @@ class GalaxyGalaxyLens(object):
 
         :return: x-pos, y-pos
         """
-        if not hasattr(self, '_image_positions'):
+        if not hasattr(self, "_image_positions"):
             kwargs_model, kwargs_params = self.lenstronomy_kwargs(band=None)
-            lens_model_list = kwargs_model['lens_model_list']
+            lens_model_list = kwargs_model["lens_model_list"]
             lens_model_class = LensModel(lens_model_list=lens_model_list)
             lens_eq_solver = LensEquationSolver(lens_model_class)
             source_pos_x, source_pos_y = self.source_position
 
-            kwargs_lens = kwargs_params['kwargs_lens']
+            kwargs_lens = kwargs_params["kwargs_lens"]
             # TODO: analytical solver possible but currently does not support the convergence term
-            self._image_positions = lens_eq_solver.image_position_from_source(source_pos_x, source_pos_y, kwargs_lens,
-                                                                              solver='lenstronomy',
-                                                                              search_window=self.einstein_radius*6,
-                                                                              min_distance=self.einstein_radius*6/100
-                                                                              )
+            self._image_positions = lens_eq_solver.image_position_from_source(
+                source_pos_x,
+                source_pos_y,
+                kwargs_lens,
+                solver="lenstronomy",
+                search_window=self.einstein_radius * 6,
+                min_distance=self.einstein_radius * 6 / 100,
+            )
         return self._image_positions
 
-    def validity_test(self, min_image_separation=0, max_image_separation=10, mag_arc_limit=None):
+    def validity_test(
+        self, min_image_separation=0, max_image_separation=10, mag_arc_limit=None
+    ):
         """
         check whether lensing configuration matches selection and plausibility criteria
 
@@ -117,8 +136,8 @@ class GalaxyGalaxyLens(object):
         :return: boolean
         """
         # Criteria 1:The redshift of the lens (z_lens) must be less than the redshift of the source (z_source).
-        z_lens = self._lens_dict['z']
-        z_source = self._source_dict['z']
+        z_lens = self._lens_dict["z"]
+        z_source = self._source_dict["z"]
         if z_lens >= z_source:
             return False
 
@@ -132,7 +151,7 @@ class GalaxyGalaxyLens(object):
         # angular Einstein radius of the lensing configuration (times sqrt(2)).
         center_lens, center_source = self.lens_position, self.source_position
 
-        if np.sum((center_lens - center_source) ** 2) > self._theta_E_sis ** 2 * 2:
+        if np.sum((center_lens - center_source) ** 2) > self._theta_E_sis**2 * 2:
             return False
 
         # Criteria 4: The lensing configuration must produce at least two SL images.
@@ -154,7 +173,9 @@ class GalaxyGalaxyLens(object):
             host_mag = self.host_magnification()
             for band, mag_limit_band in mag_arc_limit.items():
                 mag_source = self.extended_source_magnitude(band)
-                mag_arc = mag_source - 2.5 * np.log10(host_mag)  # lensing magnification results in a shift in magnitude
+                mag_arc = mag_source - 2.5 * np.log10(
+                    host_mag
+                )  # lensing magnification results in a shift in magnitude
                 if mag_arc < mag_limit_band:
                     bool_mag_limit = True
                     break
@@ -170,7 +191,7 @@ class GalaxyGalaxyLens(object):
 
         :return: lens redshift
         """
-        return self._lens_dict['z']
+        return self._lens_dict["z"]
 
     @property
     def source_redshift(self):
@@ -178,7 +199,7 @@ class GalaxyGalaxyLens(object):
 
         :return: source redshift
         """
-        return self._source_dict['z']
+        return self._source_dict["z"]
 
     @property
     def einstein_radius(self):
@@ -195,8 +216,12 @@ class GalaxyGalaxyLens(object):
 
         :return: e1_light, e2_light, e1_mass, e2_mass
         """
-        e1_light, e2_light = float(self._lens_dict['e1_light']), float(self._lens_dict['e2_light'])
-        e1_mass, e2_mass = float(self._lens_dict['e1_mass']), float(self._lens_dict['e2_mass'])
+        e1_light, e2_light = float(self._lens_dict["e1_light"]), float(
+            self._lens_dict["e2_light"]
+        )
+        e1_mass, e2_mass = float(self._lens_dict["e1_mass"]), float(
+            self._lens_dict["e2_mass"]
+        )
         return e1_light, e2_light, e1_mass, e2_mass
 
     def deflector_stellar_mass(self):
@@ -204,14 +229,14 @@ class GalaxyGalaxyLens(object):
 
         :return: stellar mass of deflector
         """
-        return self._lens_dict['stellar_mass']
+        return self._lens_dict["stellar_mass"]
 
     def deflector_velocity_dispersion(self):
         """
 
         :return: velocity dispersion [km/s]
         """
-        return self._lens_dict['vel_disp']
+        return self._lens_dict["vel_disp"]
 
     def los_linear_distortions(self):
         """
@@ -224,7 +249,7 @@ class GalaxyGalaxyLens(object):
         mixgauss_means = self._mixgauss_means
         mixgauss_stds = self._mixgauss_stds
         mixgauss_weights = self._mixgauss_weights
-        if not hasattr(self, '_gamma'):
+        if not hasattr(self, "_gamma"):
             mixture = GaussianMixtureModel(
                 means=mixgauss_means,
                 stds=mixgauss_stds,
@@ -235,7 +260,7 @@ class GalaxyGalaxyLens(object):
             gamma1 = gamma * np.cos(2 * phi)
             gamma2 = gamma * np.sin(2 * phi)
             self._gamma = [gamma1, gamma2]
-        if not hasattr(self, '_kappa'):
+        if not hasattr(self, "_kappa"):
             self._kappa = np.random.normal(loc=0, scale=0.05)
         return self._gamma[0], self._gamma[1], self._kappa
 
@@ -247,7 +272,7 @@ class GalaxyGalaxyLens(object):
         :type band: string
         :return: magnitude of deflector in given band
         """
-        band_string = str('mag_' + band)
+        band_string = str("mag_" + band)
         return self._lens_dict[band_string]
 
     def point_source_magnitude(self, band, lensed=False):
@@ -262,7 +287,7 @@ class GalaxyGalaxyLens(object):
         :type lensed: bool
         :return: point source magnitude
         """
-        band_string = str('mag_' + band)
+        band_string = str("mag_" + band)
         # TODO: might have to change conventions between extended and point source
         source_mag = self._source_dict[band_string]
         if lensed:
@@ -281,7 +306,7 @@ class GalaxyGalaxyLens(object):
         :type lensed: bool
         :return: magnitude of source in given band
         """
-        band_string = str('mag_' + band)
+        band_string = str("mag_" + band)
         # TODO: might have to change conventions between extended and point source
         source_mag = self._source_dict[band_string]
         if lensed:
@@ -295,7 +320,7 @@ class GalaxyGalaxyLens(object):
 
         :return: signed magnification of point sources in same order as image positions
         """
-        if not hasattr(self, '_ps_magnification'):
+        if not hasattr(self, "_ps_magnification"):
             lens_model_list, kwargs_lens = self.lens_model_lenstronomy()
             lensModel = LensModel(lens_model_list=lens_model_list)
             img_x, img_y = self.image_positions()
@@ -309,24 +334,34 @@ class GalaxyGalaxyLens(object):
 
         :return: integrated magnification factor of host magnitude
         """
-        if not hasattr(self, '_host_magnification'):
+        if not hasattr(self, "_host_magnification"):
             kwargs_model, kwargs_params = self.lenstronomy_kwargs(band=None)
-            lightModel = LightModel(light_model_list=kwargs_model.get('source_light_model_list', []))
-            lensModel = LensModel(lens_model_list=kwargs_model.get('lens_model_list', []))
+            lightModel = LightModel(
+                light_model_list=kwargs_model.get("source_light_model_list", [])
+            )
+            lensModel = LensModel(
+                lens_model_list=kwargs_model.get("lens_model_list", [])
+            )
             theta_E = self.einstein_radius
             center_source = self.source_position
 
-            kwargs_source_mag = kwargs_params['kwargs_source']
-            kwargs_source_amp = data_util.magnitude2amplitude(lightModel, kwargs_source_mag, magnitude_zero_point=0)
+            kwargs_source_mag = kwargs_params["kwargs_source"]
+            kwargs_source_amp = data_util.magnitude2amplitude(
+                lightModel, kwargs_source_mag, magnitude_zero_point=0
+            )
 
             num_pix = 200
             delta_pix = theta_E * 4 / num_pix
             x, y = util.make_grid(numPix=200, deltapix=delta_pix)
             x += center_source[0]
             y += center_source[1]
-            beta_x, beta_y = lensModel.ray_shooting(x, y, kwargs_params['kwargs_lens'])
-            flux_lensed = np.sum(lightModel.surface_brightness(beta_x, beta_y, kwargs_source_amp))
-            flux_no_lens = np.sum(lightModel.surface_brightness(x, y, kwargs_source_amp))
+            beta_x, beta_y = lensModel.ray_shooting(x, y, kwargs_params["kwargs_lens"])
+            flux_lensed = np.sum(
+                lightModel.surface_brightness(beta_x, beta_y, kwargs_source_amp)
+            )
+            flux_no_lens = np.sum(
+                lightModel.surface_brightness(x, y, kwargs_source_amp)
+            )
             if flux_no_lens > 0:
                 self._host_magnification = flux_lensed / flux_no_lens
             else:
@@ -342,50 +377,76 @@ class GalaxyGalaxyLens(object):
 
         """
         lens_model_list, kwargs_lens = self.lens_model_lenstronomy()
-        kwargs_model = {'lens_light_model_list': ['SERSIC_ELLIPSE'],
-                        'lens_model_list':  lens_model_list}
+        kwargs_model = {
+            "lens_light_model_list": ["SERSIC_ELLIPSE"],
+            "lens_model_list": lens_model_list,
+        }
 
         center_lens, center_source = self.lens_position, self.source_position
-        if self._source_type == 'extended':
+        if self._source_type == "extended":
             # convert radian to arc seconds
             if band is None:
                 mag_source = 1
             else:
                 mag_source = self.extended_source_magnitude(band)
-            size_source_arcsec = float(self._source_dict['angular_size']) / constants.arcsec
-            kwargs_model['source_light_model_list'] = ['SERSIC_ELLIPSE']
-            kwargs_source = [{'magnitude': mag_source, 'R_sersic': size_source_arcsec,
-                              'n_sersic': float(self._source_dict['n_sersic']),
-                              'e1': float(self._source_dict['e1']), 'e2': float(self._source_dict['e2']),
-                              'center_x': center_source[0], 'center_y': center_source[1]}]
+            size_source_arcsec = (
+                float(self._source_dict["angular_size"]) / constants.arcsec
+            )
+            kwargs_model["source_light_model_list"] = ["SERSIC_ELLIPSE"]
+            kwargs_source = [
+                {
+                    "magnitude": mag_source,
+                    "R_sersic": size_source_arcsec,
+                    "n_sersic": float(self._source_dict["n_sersic"]),
+                    "e1": float(self._source_dict["e1"]),
+                    "e2": float(self._source_dict["e2"]),
+                    "center_x": center_source[0],
+                    "center_y": center_source[1],
+                }
+            ]
         else:
             kwargs_source = None
 
-        if self._source_type == 'point_source':
-            kwargs_model['point_source_model'] = ['LENSED_POSITION']
+        if self._source_type == "point_source":
+            kwargs_model["point_source_model"] = ["LENSED_POSITION"]
             img_x, img_y = self.image_positions()
             if band is None:
                 image_magnitudes = np.abs(self.point_source_magnification())
             else:
                 image_magnitudes = self.point_source_magnitude(band=band, lensed=True)
-            kwargs_ps = [{'ra_image': img_x, 'dec_image': img_y, 'point_amp': image_magnitudes}]
+            kwargs_ps = [
+                {"ra_image": img_x, "dec_image": img_y, "point_amp": image_magnitudes}
+            ]
         else:
             kwargs_ps = None
 
         e1_light_lens, e2_light_lens, e1_mass, e2_mass = self.deflector_ellipticity()
-        size_lens_arcsec = self._lens_dict['angular_size'] / constants.arcsec  # convert radian to arc seconds
+        size_lens_arcsec = (
+            self._lens_dict["angular_size"] / constants.arcsec
+        )  # convert radian to arc seconds
 
         if band is None:
             mag_lens = 1
         else:
             mag_lens = self.deflector_magnitude(band)
-        kwargs_lens_light = [{'magnitude': mag_lens, 'R_sersic': size_lens_arcsec,
-                              'n_sersic': float(self._source_dict['n_sersic']),
-                              'e1': e1_light_lens, 'e2': e2_light_lens,
-                              'center_x': center_lens[0], 'center_y': center_lens[1]}]
+        kwargs_lens_light = [
+            {
+                "magnitude": mag_lens,
+                "R_sersic": size_lens_arcsec,
+                "n_sersic": float(self._source_dict["n_sersic"]),
+                "e1": e1_light_lens,
+                "e2": e2_light_lens,
+                "center_x": center_lens[0],
+                "center_y": center_lens[1],
+            }
+        ]
 
-        kwargs_params = {'kwargs_lens': kwargs_lens, 'kwargs_source': kwargs_source,
-                         'kwargs_lens_light': kwargs_lens_light, 'kwargs_ps': kwargs_ps}
+        kwargs_params = {
+            "kwargs_lens": kwargs_lens,
+            "kwargs_source": kwargs_source,
+            "kwargs_lens_light": kwargs_lens_light,
+            "kwargs_ps": kwargs_ps,
+        }
         return kwargs_model, kwargs_params
 
     def lens_model_lenstronomy(self):
@@ -394,15 +455,23 @@ class GalaxyGalaxyLens(object):
 
         :return: lens_model_list, kwargs_lens
         """
-        lens_model_list = ['EPL', 'SHEAR', 'CONVERGENCE']
+        lens_model_list = ["EPL", "SHEAR", "CONVERGENCE"]
         theta_E = self.einstein_radius
         e1_light_lens, e2_light_lens, e1_mass, e2_mass = self.deflector_ellipticity()
         center_lens = self.lens_position
         gamma1, gamma2, kappa_ext = self.los_linear_distortions()
-        kwargs_lens = [{'theta_E': theta_E, 'gamma': 2, 'e1': e1_mass, 'e2': e2_mass,
-                        'center_x': center_lens[0], 'center_y': center_lens[1]},
-                       {'gamma1': gamma1, 'gamma2': gamma2, 'ra_0': 0, 'dec_0': 0},
-                       {'kappa': kappa_ext, 'ra_0': 0, 'dec_0': 0}]
+        kwargs_lens = [
+            {
+                "theta_E": theta_E,
+                "gamma": 2,
+                "e1": e1_mass,
+                "e2": e2_mass,
+                "center_x": center_lens[0],
+                "center_y": center_lens[1],
+            },
+            {"gamma1": gamma1, "gamma2": gamma2, "ra_0": 0, "dec_0": 0},
+            {"kappa": kappa_ext, "ra_0": 0, "dec_0": 0},
+        ]
         return lens_model_list, kwargs_lens
 
 
@@ -415,28 +484,34 @@ def image_separation_from_positions(image_positions):
     :return: image separation in arc-seconds
     """
     if len(image_positions[0]) == 2:
-        image_separation = np.sqrt((image_positions[0][0] - image_positions[0][1]) ** 2 + (
-                image_positions[1][0] - image_positions[1][1]) ** 2)
+        image_separation = np.sqrt(
+            (image_positions[0][0] - image_positions[0][1]) ** 2
+            + (image_positions[1][0] - image_positions[1][1]) ** 2
+        )
     else:
         coords = np.stack((image_positions[0], image_positions[1]), axis=-1)
-        separations = np.sqrt(np.sum((coords[:, np.newaxis] - coords[np.newaxis, :]) ** 2, axis=-1))
+        separations = np.sqrt(
+            np.sum((coords[:, np.newaxis] - coords[np.newaxis, :]) ** 2, axis=-1)
+        )
         image_separation = np.max(separations)
     return image_separation
 
 
 def theta_e_when_source_infinity(deflector_dict=None, v_sigma=None):
     """
-            calculate Einstein radius in arc-seconds for a source at infinity
+    calculate Einstein radius in arc-seconds for a source at infinity
 
-            :param deflector_dict: deflector properties
-            :param v_sigma: velocity dispersion in km/s
-            :return: Einstein radius in arc-seconds
-            """
+    :param deflector_dict: deflector properties
+    :param v_sigma: velocity dispersion in km/s
+    :return: Einstein radius in arc-seconds
+    """
     if v_sigma is None:
         if deflector_dict is None:
             raise ValueError("Either deflector_dict or v_sigma must be provided")
         else:
-            v_sigma = deflector_dict['vel_disp']
+            v_sigma = deflector_dict["vel_disp"]
 
-    theta_E_infinity = 4 * np.pi * (v_sigma * 1000. / constants.c) ** 2 / constants.arcsec
+    theta_E_infinity = (
+        4 * np.pi * (v_sigma * 1000.0 / constants.c) ** 2 / constants.arcsec
+    )
     return theta_E_infinity

--- a/sim_pipeline/galaxy_galaxy_lens_pop.py
+++ b/sim_pipeline/galaxy_galaxy_lens_pop.py
@@ -1,5 +1,8 @@
 from sim_pipeline.Pipelines.skypy_pipeline import SkyPyPipeline
-from sim_pipeline.galaxy_galaxy_lens import GalaxyGalaxyLens, theta_e_when_source_infinity
+from sim_pipeline.galaxy_galaxy_lens import (
+    GalaxyGalaxyLens,
+    theta_e_when_source_infinity,
+)
 import numpy as np
 import warnings
 
@@ -9,9 +12,18 @@ class GalaxyGalaxyLensPop(object):
     class to perform samples of galaxy-galaxy lensing
     """
 
-    def __init__(self, deflector_type='elliptical', source_type='galaxies', kwargs_deflector_cut=None,
-                 kwargs_source_cut=None, kwargs_mass2light=None, skypy_config=None, sky_area=None, filters=None,
-                 cosmo=None):
+    def __init__(
+        self,
+        deflector_type="elliptical",
+        source_type="galaxies",
+        kwargs_deflector_cut=None,
+        kwargs_source_cut=None,
+        kwargs_mass2light=None,
+        skypy_config=None,
+        sky_area=None,
+        filters=None,
+        cosmo=None,
+    ):
         """
 
         :param deflector_type: type of the lens
@@ -31,44 +43,71 @@ class GalaxyGalaxyLensPop(object):
         """
         if sky_area is None:
             from astropy.units import Quantity
-            sky_area = Quantity(value=0.1, unit='deg2')
+
+            sky_area = Quantity(value=0.1, unit="deg2")
             warnings.warn("No sky area provided, instead uses 0.1 deg2")
-        if deflector_type in ['elliptical', 'all-galaxies'] or source_type in ['galaxies']:
-            pipeline = SkyPyPipeline(skypy_config=skypy_config, sky_area=sky_area, filters=filters)
+        if deflector_type in ["elliptical", "all-galaxies"] or source_type in [
+            "galaxies"
+        ]:
+            pipeline = SkyPyPipeline(
+                skypy_config=skypy_config, sky_area=sky_area, filters=filters
+            )
         if kwargs_deflector_cut is None:
             kwargs_deflector_cut = {}
         if kwargs_mass2light is None:
             kwargs_mass2light = {}
         if cosmo is None:
-            warnings.warn("No cosmology provided, instead uses flat LCDM with default parameters")
+            warnings.warn(
+                "No cosmology provided, instead uses flat LCDM with default parameters"
+            )
             from astropy.cosmology import FlatLambdaCDM
+
             cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-        if deflector_type == 'elliptical':
-            from sim_pipeline.Deflectors.elliptical_lens_galaxies import EllipticalLensGalaxies
-            self._lens_galaxies = EllipticalLensGalaxies(pipeline.red_galaxies, kwargs_cut=kwargs_deflector_cut,
-                                                        kwargs_mass2light=kwargs_mass2light, cosmo=cosmo,
-                                                        sky_area=sky_area)
-        elif deflector_type == 'all-galaxies':
+        if deflector_type == "elliptical":
+            from sim_pipeline.Deflectors.elliptical_lens_galaxies import (
+                EllipticalLensGalaxies,
+            )
+
+            self._lens_galaxies = EllipticalLensGalaxies(
+                pipeline.red_galaxies,
+                kwargs_cut=kwargs_deflector_cut,
+                kwargs_mass2light=kwargs_mass2light,
+                cosmo=cosmo,
+                sky_area=sky_area,
+            )
+        elif deflector_type == "all-galaxies":
             from sim_pipeline.Deflectors.all_lens_galaxies import AllLensGalaxies
-            self._lens_galaxies = AllLensGalaxies(pipeline.red_galaxies, pipeline.blue_galaxies,
-                                                  kwargs_cut=kwargs_deflector_cut, kwargs_mass2light=kwargs_mass2light,
-                                                  cosmo=cosmo, sky_area=sky_area)
+
+            self._lens_galaxies = AllLensGalaxies(
+                pipeline.red_galaxies,
+                pipeline.blue_galaxies,
+                kwargs_cut=kwargs_deflector_cut,
+                kwargs_mass2light=kwargs_mass2light,
+                cosmo=cosmo,
+                sky_area=sky_area,
+            )
         else:
-            raise ValueError('deflector_type %s is not supported' % deflector_type)
+            raise ValueError("deflector_type %s is not supported" % deflector_type)
 
         if kwargs_source_cut is None:
             kwargs_source_cut = {}
-        if source_type == 'galaxies':
+        if source_type == "galaxies":
             from sim_pipeline.Sources.galaxies import Galaxies
-            self._sources = Galaxies(pipeline.blue_galaxies, kwargs_cut=kwargs_source_cut, cosmo=cosmo,
-                                     sky_area=sky_area)
-            self._source_model_type = 'extended'
-        elif source_type == 'quasars':
+
+            self._sources = Galaxies(
+                pipeline.blue_galaxies,
+                kwargs_cut=kwargs_source_cut,
+                cosmo=cosmo,
+                sky_area=sky_area,
+            )
+            self._source_model_type = "extended"
+        elif source_type == "quasars":
             from sim_pipeline.Sources.quasars import Quasars
+
             self._sources = Quasars(cosmo=cosmo, sky_area=sky_area)
-            self._source_model_type = 'point_source'
+            self._source_model_type = "point_source"
         else:
-            raise ValueError('source_type %s is not supported' % source_type)
+            raise ValueError("source_type %s is not supported" % source_type)
         self.cosmo = cosmo
         self.f_sky = sky_area
 
@@ -85,8 +124,12 @@ class GalaxyGalaxyLensPop(object):
         while True:
             source = self._sources.draw_source()
             lens = self._lens_galaxies.draw_deflector()
-            gg_lens = GalaxyGalaxyLens(deflector_dict=lens, source_dict=source, cosmo=self.cosmo,
-                             source_type=self._source_model_type)
+            gg_lens = GalaxyGalaxyLens(
+                deflector_dict=lens,
+                source_dict=source,
+                cosmo=self.cosmo,
+                source_type=self._source_model_type,
+            )
             if gg_lens.validity_test(**kwargs_lens_cut):
                 return gg_lens
 
@@ -114,7 +157,9 @@ class GalaxyGalaxyLensPop(object):
         testarea is in units of arcsec^2, f_sky is in units of deg^2. 1 deg^2 = 12960000 arcsec^2
         """
         num_sources = self._sources.source_number()
-        num_sources_tested_mean = (testarea * num_sources) / (12960000 * self.f_sky.to_value('deg2'))
+        num_sources_tested_mean = (testarea * num_sources) / (
+            12960000 * self.f_sky.to_value("deg2")
+        )
         return num_sources_tested_mean
 
     def get_num_sources_tested(self, testarea=None, num_sources_tested_mean=None):
@@ -159,13 +204,18 @@ class GalaxyGalaxyLensPop(object):
                 n = 0
                 while n < num_sources_tested:
                     source = self._sources.draw_source()
-                    gg_lens = GalaxyGalaxyLens(deflector_dict=lens, source_dict=source, cosmo=self.cosmo,
-                                               test_area=test_area, source_type=self._source_model_type)
+                    gg_lens = GalaxyGalaxyLens(
+                        deflector_dict=lens,
+                        source_dict=source,
+                        cosmo=self.cosmo,
+                        test_area=test_area,
+                        source_type=self._source_model_type,
+                    )
                     # Check the validity of the lens system
                     if gg_lens.validity_test(**kwargs_lens_cuts):
                         gg_lens_population.append(gg_lens)
                         # if a lens system passes the validity test, code should exit the loop.
-                        #so, n should be greater or equal to num_sources_tested which will break the
+                        # so, n should be greater or equal to num_sources_tested which will break the
                         ## the while loop (instead of this one can simply use break).
                         n = num_sources_tested
                     else:

--- a/sim_pipeline/galaxy_galaxy_lens_pop.py
+++ b/sim_pipeline/galaxy_galaxy_lens_pop.py
@@ -8,9 +8,7 @@ import warnings
 
 
 class GalaxyGalaxyLensPop(object):
-    """
-    class to perform samples of galaxy-galaxy lensing
-    """
+    """Class to perform samples of galaxy-galaxy lensing."""
 
     def __init__(
         self,
@@ -112,14 +110,14 @@ class GalaxyGalaxyLensPop(object):
         self.f_sky = sky_area
 
     def select_lens_at_random(self, **kwargs_lens_cut):
-        """
-        draw a random lens within the cuts of the lens and source, with possible additional cut in the lensing
-        configuration.
+        """Draw a random lens within the cuts of the lens and source, with possible
+        additional cut in the lensing configuration.
 
-        #TODO: make sure mass function is preserved,
-        # as well as option to draw all lenses within the cuts within the area
+        #TODO: make sure mass function is preserved, # as well as option to draw all
+        lenses within the cuts within the area
 
-        :return: GalaxyGalaxyLens() instance with parameters of the deflector and lens and source light
+        :return: GalaxyGalaxyLens() instance with parameters of the deflector and lens
+            and source light
         """
         while True:
             source = self._sources.draw_source()
@@ -134,27 +132,26 @@ class GalaxyGalaxyLensPop(object):
                 return gg_lens
 
     def deflector_number(self):
-        """
-        number of potential deflectors (meaning all objects with mass that are being considered to have potential
-        sources behind them)
+        """Number of potential deflectors (meaning all objects with mass that are being
+        considered to have potential sources behind them)
 
         :return: number of potential deflectors
         """
         return self._lens_galaxies.deflector_number()
 
     def source_number(self):
-        """
-        number of sources that are being considered to be placed in the sky area potentially aligned behind deflectors
+        """Number of sources that are being considered to be placed in the sky area
+        potentially aligned behind deflectors.
 
         :return: number of sources
         """
         return self._sources.source_number()
 
     def get_num_sources_tested_mean(self, testarea):
-        """
-        Compute the mean of source galaxies needed to be tested within the test area.
-        num_sources_tested_mean/ testarea = num_sources/ f_sky;
-        testarea is in units of arcsec^2, f_sky is in units of deg^2. 1 deg^2 = 12960000 arcsec^2
+        """Compute the mean of source galaxies needed to be tested within the test area.
+
+        num_sources_tested_mean/ testarea = num_sources/ f_sky; testarea is in units of
+        arcsec^2, f_sky is in units of deg^2. 1 deg^2 = 12960000 arcsec^2
         """
         num_sources = self._sources.source_number()
         num_sources_tested_mean = (testarea * num_sources) / (
@@ -163,24 +160,22 @@ class GalaxyGalaxyLensPop(object):
         return num_sources_tested_mean
 
     def get_num_sources_tested(self, testarea=None, num_sources_tested_mean=None):
-        """
-        Draw a realization of the expected distribution (Poisson) around the mean
-        for the number of source galaxies tested.
-        """
+        """Draw a realization of the expected distribution (Poisson) around the mean for
+        the number of source galaxies tested."""
         if num_sources_tested_mean is None:
             num_sources_tested_mean = self.get_num_sources_tested_mean(testarea)
         num_sources_range = np.random.poisson(lam=num_sources_tested_mean)
         return num_sources_range
 
     def draw_population(self, kwargs_lens_cuts):
-        """
-        return full population list of all lenses within the area
-        # TODO: need to implement a version of it. (improve the algorithm)
-            Draw a population of galaxy-galaxy lenses within the area.
+        """Return full population list of all lenses within the area # TODO: need to
+        implement a version of it. (improve the algorithm) Draw a population of galaxy-
+        galaxy lenses within the area.
 
         :param kwargs_lens_cuts: validity test keywords
         :type kwargs_lens_cuts: dict
-        :return: List of GalaxyGalaxyLens instances with parameters of the deflectors and lens and source light.
+        :return: List of GalaxyGalaxyLens instances with parameters of the deflectors
+            and lens and source light.
         :rtype: list
         """
 
@@ -224,8 +219,7 @@ class GalaxyGalaxyLensPop(object):
 
 
 def draw_test_area(deflector):
-    """
-    draw a test area around the deflector
+    """Draw a test area around the deflector.
 
     :param deflector: deflector dictionary
     :return: test area in arcsec^2

--- a/sim_pipeline/galaxy_galaxy_lens_pop.py
+++ b/sim_pipeline/galaxy_galaxy_lens_pop.py
@@ -34,7 +34,8 @@ class GalaxyGalaxyLensPop(object):
         :type kwargs_source_cut: dict
         :param skypy_config: path to SkyPy configuration yaml file
         :type skypy_config: string
-        :param sky_area: Sky area over which galaxies are sampled. Must be in units of solid angle.
+        :param sky_area: Sky area over which galaxies are sampled. Must be in units of
+            solid angle.
         :type sky_area: `~astropy.units.Quantity`
         :param filters: filters for SED integration
         :type filters: list of strings or None
@@ -209,9 +210,10 @@ class GalaxyGalaxyLensPop(object):
                     # Check the validity of the lens system
                     if gg_lens.validity_test(**kwargs_lens_cuts):
                         gg_lens_population.append(gg_lens)
-                        # if a lens system passes the validity test, code should exit the loop.
-                        # so, n should be greater or equal to num_sources_tested which will break the
-                        ## the while loop (instead of this one can simply use break).
+                        # if a lens system passes the validity test, code should exit
+                        # the loop. so, n should be greater or equal to
+                        # num_sources_tested which will break the the while loop
+                        # (instead of this one can simply use break).
                         n = num_sources_tested
                     else:
                         n += 1

--- a/sim_pipeline/image_simulation.py
+++ b/sim_pipeline/image_simulation.py
@@ -3,12 +3,13 @@ import galsim
 from astropy.visualization import make_lupton_rgb
 
 
-
-def simulate_image(lens_class, band, num_pix, add_noise=True, observatory='LSST', **kwargs):
+def simulate_image(
+    lens_class, band, num_pix, add_noise=True, observatory="LSST", **kwargs
+):
     """
     Creates an image of a selected lens with noise.
 
-    :param lens_class: class object containing all information of the lensing system (e.g., 
+    :param lens_class: class object containing all information of the lensing system (e.g.,
      GalaxyGalaxyLens())
     :param band: imaging band
     :param num_pix: number of pixels per axis
@@ -22,26 +23,39 @@ def simulate_image(lens_class, band, num_pix, add_noise=True, observatory='LSST'
     """
     kwargs_model, kwargs_params = lens_class.lenstronomy_kwargs(band)
     from sim_pipeline.Observations import image_quality_lenstronomy
-    kwargs_single_band = image_quality_lenstronomy.kwargs_single_band(observatory=observatory, 
-                                                                      band=band, **kwargs)
 
-    sim_api = SimAPI(numpix=num_pix, kwargs_single_band=kwargs_single_band, kwargs_model=
-                     kwargs_model)
+    kwargs_single_band = image_quality_lenstronomy.kwargs_single_band(
+        observatory=observatory, band=band, **kwargs
+    )
+
+    sim_api = SimAPI(
+        numpix=num_pix, kwargs_single_band=kwargs_single_band, kwargs_model=kwargs_model
+    )
     kwargs_lens_light, kwargs_source, kwargs_ps = sim_api.magnitude2amplitude(
-        kwargs_lens_light_mag=kwargs_params.get('kwargs_lens_light', None),
-        kwargs_source_mag=kwargs_params.get('kwargs_source', None),
-        kwargs_ps_mag=kwargs_params.get('kwargs_ps', None))
-    kwargs_numerics = {'point_source_supersampling_factor': 1, 'supersampling_factor': 3}
+        kwargs_lens_light_mag=kwargs_params.get("kwargs_lens_light", None),
+        kwargs_source_mag=kwargs_params.get("kwargs_source", None),
+        kwargs_ps_mag=kwargs_params.get("kwargs_ps", None),
+    )
+    kwargs_numerics = {
+        "point_source_supersampling_factor": 1,
+        "supersampling_factor": 3,
+    }
     image_model = sim_api.image_model_class(kwargs_numerics)
-    kwargs_lens = kwargs_params.get('kwargs_lens', None)
-    image = image_model.image(kwargs_lens=kwargs_lens, kwargs_source=kwargs_source, 
-                              kwargs_lens_light=kwargs_lens_light, kwargs_ps=kwargs_ps)
+    kwargs_lens = kwargs_params.get("kwargs_lens", None)
+    image = image_model.image(
+        kwargs_lens=kwargs_lens,
+        kwargs_source=kwargs_source,
+        kwargs_lens_light=kwargs_lens_light,
+        kwargs_ps=kwargs_ps,
+    )
     if add_noise:
         image += sim_api.noise_for_model(model=image)
     return image
 
 
-def sharp_image(lens_class, band, mag_zero_point, delta_pix, num_pix, with_deflector=True):
+def sharp_image(
+    lens_class, band, mag_zero_point, delta_pix, num_pix, with_deflector=True
+):
     """
     Creates a high resolution image of a selected lens.
 
@@ -54,50 +68,63 @@ def sharp_image(lens_class, band, mag_zero_point, delta_pix, num_pix, with_defle
     :return: 2d array unblurred image
     """
     kwargs_model, kwargs_params = lens_class.lenstronomy_kwargs(band)
-    kwargs_band = {'pixel_scale': delta_pix, 'magnitude_zero_point': mag_zero_point,
-                   'background_noise': 0, # these are keywords not being used but need to be 
-                                                    ## set in SimAPI
-                   'psf_type': 'NONE',  # these are keywords not being used but need to be set 
-                                                            ##in SimAPI
-                   'exposure_time': 1}  # these are keywords not being used but need to be set in 
-                                            ##SimAPI
-    sim_api = SimAPI(numpix=num_pix, kwargs_single_band=kwargs_band, kwargs_model=kwargs_model)
+    kwargs_band = {
+        "pixel_scale": delta_pix,
+        "magnitude_zero_point": mag_zero_point,
+        "background_noise": 0,  # these are keywords not being used but need to be
+        ## set in SimAPI
+        "psf_type": "NONE",  # these are keywords not being used but need to be set
+        ##in SimAPI
+        "exposure_time": 1,
+    }  # these are keywords not being used but need to be set in
+    ##SimAPI
+    sim_api = SimAPI(
+        numpix=num_pix, kwargs_single_band=kwargs_band, kwargs_model=kwargs_model
+    )
     kwargs_lens_light, kwargs_source, kwargs_ps = sim_api.magnitude2amplitude(
-        kwargs_lens_light_mag=kwargs_params.get('kwargs_lens_light', None),
-        kwargs_source_mag=kwargs_params.get('kwargs_source', None),
-        kwargs_ps_mag=kwargs_params.get('kwargs_ps', None))
-    kwargs_numerics = {'supersampling_factor': 1}
+        kwargs_lens_light_mag=kwargs_params.get("kwargs_lens_light", None),
+        kwargs_source_mag=kwargs_params.get("kwargs_source", None),
+        kwargs_ps_mag=kwargs_params.get("kwargs_ps", None),
+    )
+    kwargs_numerics = {"supersampling_factor": 1}
     image_model = sim_api.image_model_class(kwargs_numerics)
-    kwargs_lens = kwargs_params.get('kwargs_lens', None)
-    image = image_model.image(kwargs_lens=kwargs_lens, kwargs_source=kwargs_source, 
-                              kwargs_lens_light=kwargs_lens_light, kwargs_ps=kwargs_ps, 
-                              unconvolved=True, source_add=True, lens_light_add=with_deflector,
-                              point_source_add=False)
+    kwargs_lens = kwargs_params.get("kwargs_lens", None)
+    image = image_model.image(
+        kwargs_lens=kwargs_lens,
+        kwargs_source=kwargs_source,
+        kwargs_lens_light=kwargs_lens_light,
+        kwargs_ps=kwargs_ps,
+        unconvolved=True,
+        source_add=True,
+        lens_light_add=with_deflector,
+        point_source_add=False,
+    )
     return image
 
 
 def galsimobj(image, pix_scale, flux):
     """
     Creates an interpolated version of the given image with specified flux.
-    
+
     :param image: image that need to be interpolated
     :param pix_scale: pixel scale to be asigned to the interpolated image
     :param flux: flux value to be asigned to the interpolated image
     :returns : interpolated image with specified pixel scale and flux"""
-    gso = galsim.InterpolatedImage(galsim.Image(image), scale = pix_scale, flux = flux)
+    gso = galsim.InterpolatedImage(galsim.Image(image), scale=pix_scale, flux=flux)
     return gso
 
 
 def galsimobj_true_flux(image, pix_scale):
     """
     Creates an interpolated version of the given image with preserved flux.
-    
+
     :param image: image that need to be interpolated
     :param pix_scale: pixel scale to be asigned to the interpolated image
     :param flux: flux value to be asigned to the interpolated image
     :returns : interpolated image with specified pixel scale and flux"""
-    gso_test = galsim.InterpolatedImage(galsim.Image(image), scale = pix_scale, 
-                                        normalization='flux')
+    gso_test = galsim.InterpolatedImage(
+        galsim.Image(image), scale=pix_scale, normalization="flux"
+    )
     return gso_test
 
 
@@ -112,12 +139,27 @@ def sharp_rgb_image(lens_class, rgb_band_list, mag_zero_point, delta_pix, num_pi
     :param num_pix: number of pixels per axis
     :return: rgb image
     """
-    image_r = sharp_image(lens_class=lens_class, band=rgb_band_list[0], 
-                          mag_zero_point=mag_zero_point, delta_pix=delta_pix, num_pix=num_pix)
-    image_g = sharp_image(lens_class=lens_class, band=rgb_band_list[1], 
-                          mag_zero_point=mag_zero_point, delta_pix=delta_pix, num_pix=num_pix)
-    image_b = sharp_image(lens_class=lens_class, band=rgb_band_list[2], 
-                          mag_zero_point=mag_zero_point, delta_pix=delta_pix, num_pix=num_pix)
+    image_r = sharp_image(
+        lens_class=lens_class,
+        band=rgb_band_list[0],
+        mag_zero_point=mag_zero_point,
+        delta_pix=delta_pix,
+        num_pix=num_pix,
+    )
+    image_g = sharp_image(
+        lens_class=lens_class,
+        band=rgb_band_list[1],
+        mag_zero_point=mag_zero_point,
+        delta_pix=delta_pix,
+        num_pix=num_pix,
+    )
+    image_b = sharp_image(
+        lens_class=lens_class,
+        band=rgb_band_list[2],
+        mag_zero_point=mag_zero_point,
+        delta_pix=delta_pix,
+        num_pix=num_pix,
+    )
     image_rgb = make_lupton_rgb(image_r, image_g, image_b, stretch=0.5)
     return image_rgb
 
@@ -129,5 +171,7 @@ def rgb_image_from_image_list(image_list, stretch):
     :param image_list: images in r, g, and b band
     :return: rgb image
     """
-    image_rgb = make_lupton_rgb(image_list[0], image_list[1], image_list[2], stretch=stretch)
+    image_rgb = make_lupton_rgb(
+        image_list[0], image_list[1], image_list[2], stretch=stretch
+    )
     return image_rgb

--- a/sim_pipeline/image_simulation.py
+++ b/sim_pipeline/image_simulation.py
@@ -6,11 +6,10 @@ from astropy.visualization import make_lupton_rgb
 def simulate_image(
     lens_class, band, num_pix, add_noise=True, observatory="LSST", **kwargs
 ):
-    """
-    Creates an image of a selected lens with noise.
+    """Creates an image of a selected lens with noise.
 
-    :param lens_class: class object containing all information of the lensing system (e.g.,
-     GalaxyGalaxyLens())
+    :param lens_class: class object containing all information of the lensing system
+        (e.g., GalaxyGalaxyLens())
     :param band: imaging band
     :param num_pix: number of pixels per axis
     :param add_noise: if True, add noise
@@ -56,8 +55,7 @@ def simulate_image(
 def sharp_image(
     lens_class, band, mag_zero_point, delta_pix, num_pix, with_deflector=True
 ):
-    """
-    Creates a high resolution image of a selected lens.
+    """Creates a high resolution image of a selected lens.
 
     :param lens_class: GalaxyGalaxyLens() object
     :param band: imaging band
@@ -103,25 +101,25 @@ def sharp_image(
 
 
 def galsimobj(image, pix_scale, flux):
-    """
-    Creates an interpolated version of the given image with specified flux.
+    """Creates an interpolated version of the given image with specified flux.
 
     :param image: image that need to be interpolated
     :param pix_scale: pixel scale to be asigned to the interpolated image
     :param flux: flux value to be asigned to the interpolated image
-    :returns : interpolated image with specified pixel scale and flux"""
+    :returns : interpolated image with specified pixel scale and flux
+    """
     gso = galsim.InterpolatedImage(galsim.Image(image), scale=pix_scale, flux=flux)
     return gso
 
 
 def galsimobj_true_flux(image, pix_scale):
-    """
-    Creates an interpolated version of the given image with preserved flux.
+    """Creates an interpolated version of the given image with preserved flux.
 
     :param image: image that need to be interpolated
     :param pix_scale: pixel scale to be asigned to the interpolated image
     :param flux: flux value to be asigned to the interpolated image
-    :returns : interpolated image with specified pixel scale and flux"""
+    :returns : interpolated image with specified pixel scale and flux
+    """
     gso_test = galsim.InterpolatedImage(
         galsim.Image(image), scale=pix_scale, normalization="flux"
     )
@@ -129,8 +127,7 @@ def galsimobj_true_flux(image, pix_scale):
 
 
 def sharp_rgb_image(lens_class, rgb_band_list, mag_zero_point, delta_pix, num_pix):
-    """
-    Creates a high resolution rgb image of a selected lens.
+    """Creates a high resolution rgb image of a selected lens.
 
     :param lens_class: GalaxyGalaxyLens() object
     :param rgb_band_list: imaging band list
@@ -165,8 +162,7 @@ def sharp_rgb_image(lens_class, rgb_band_list, mag_zero_point, delta_pix, num_pi
 
 
 def rgb_image_from_image_list(image_list, stretch):
-    """
-    Creates a rgb image using list of images in r, g, and b.
+    """Creates a rgb image using list of images in r, g, and b.
 
     :param image_list: images in r, g, and b band
     :return: rgb image

--- a/sim_pipeline/lsst_science_pipeline.py
+++ b/sim_pipeline/lsst_science_pipeline.py
@@ -1,5 +1,6 @@
 import numpy as np
 import lsst.geom as geom
+
 # Source injection
 from lsst.pipe.tasks.insertFakes import _add_fake_sources
 from sim_pipeline.image_simulation import galsimobj_true_flux
@@ -13,12 +14,13 @@ This module provides necessary functions to inject lenses to the dp0 data. For t
 the packages provided by the LSST Science Pipeline.
 """
 
+
 def DC2_cutout(ra, dec, num_pix, butler, band):
     """
     Draws a cutout from the DC2 data based on the given ra, dec pair. For this one needs to provide
-    a butler to this function. To initiate Butler, you need to specify data configuration and 
+    a butler to this function. To initiate Butler, you need to specify data configuration and
     collection of the data.
-    
+
     :param ra: ra for the cutout
     :param dec: dec for the cutout
     :param num_pix: number of pixel for the cutout
@@ -30,31 +32,28 @@ def DC2_cutout(ra, dec, num_pix, butler, band):
     skymap = butler.get("skyMap")
     point = geom.SpherePoint(ra, dec, geom.degrees)
     cutout_size = geom.ExtentI(num_pix, num_pix)
-    #print(cutout_size)
+    # print(cutout_size)
 
-
-    #Read this from the table we have at hand... 
+    # Read this from the table we have at hand...
     tract_Info = skymap.findTract(point)
     patch_Info = tract_Info.findPatch(point)
     my_tract = tract_Info.tract_id
     my_patch = patch_Info.getSequentialIndex()
     xy = geom.PointI(tract_Info.getWcs().skyToPixel(point))
-    bbox = geom.BoxI(xy - cutout_size//2, cutout_size)
-    coadd_Id_r = {
-        'tract':my_tract, 
-        'patch':my_patch,
-        'band': band
-    }
-    coadd_cut_r = butler.get("deepCoadd", parameters={'bbox':bbox}, dataId=coadd_Id_r)
+    bbox = geom.BoxI(xy - cutout_size // 2, cutout_size)
+    coadd_Id_r = {"tract": my_tract, "patch": my_patch, "band": band}
+    coadd_cut_r = butler.get("deepCoadd", parameters={"bbox": bbox}, dataId=coadd_Id_r)
     return coadd_cut_r
- 
-    
-def lens_inejection(lens_pop, num_pix, delta_pix, butler, ra, dec, lens_cut=None, flux=None):
+
+
+def lens_inejection(
+    lens_pop, num_pix, delta_pix, butler, ra, dec, lens_cut=None, flux=None
+):
     """
-    Chooses a random lens from the lens population and injects it to a DC2 cutout image. For this 
-    one needs to provide a butler to this function. To initiate Butler, you need to specify data 
+    Chooses a random lens from the lens population and injects it to a DC2 cutout image. For this
+    one needs to provide a butler to this function. To initiate Butler, you need to specify data
     configuration and collection of the data.
-    
+
     :param lens_pop: lens population from sim-pipeline
     :param num_pix: number of pixel for the cutout
     :param delta_pix: pixel scale for the lens image
@@ -64,47 +63,52 @@ def lens_inejection(lens_pop, num_pix, delta_pix, butler, ra, dec, lens_cut=None
     :param lens_cut: list of criteria for lens selection
     :param flux: flux need to be asigned to the lens image. It sould be None
     :param: path: path to save the output
-    :returns: An astropy table containing Injected lens in r-band, DC2 cutout image in r-band, 
-     cutout image with injected lens in r, g , and i band 
-    """   
-    #lens = sim_lens
+    :returns: An astropy table containing Injected lens in r-band, DC2 cutout image in r-band,
+     cutout image with injected lens in r, g , and i band
+    """
+    # lens = sim_lens
     if lens_cut is None:
         kwargs_lens_cut = {}
     else:
         kwargs_lens_cut = lens_cut
-    
-    rgb_band_list = ['r', 'g', 'i']
+
+    rgb_band_list = ["r", "g", "i"]
     lens_class = lens_pop.select_lens_at_random(**kwargs_lens_cut)
     skymap = butler.get("skyMap")
     point = geom.SpherePoint(ra, dec, geom.degrees)
     cutoutSize = geom.ExtentI(num_pix, num_pix)
-    #Read this from the table we have at hand 
+    # Read this from the table we have at hand
     tractInfo = skymap.findTract(point)
     patchInfo = tractInfo.findPatch(point)
     my_tract = tractInfo.tract_id
     my_patch = patchInfo.getSequentialIndex()
     xy = geom.PointI(tractInfo.getWcs().skyToPixel(point))
-    bbox = geom.BoxI(xy - cutoutSize//2, cutoutSize)
+    bbox = geom.BoxI(xy - cutoutSize // 2, cutoutSize)
     injected_final_image = []
-    #band_report = []
+    # band_report = []
     box_center = []
     cutout_image = []
     lens_image = []
     for band in rgb_band_list:
-        coaddId_r = {
-            'tract':my_tract, 
-            'patch':my_patch,
-            'band': band
-        }
-        
-        #coadd cutout image
-        coadd_cut_r = butler.get("deepCoadd", parameters={'bbox':bbox}, dataId=coaddId_r)
-        lens = sharp_image(lens_class=lens_class, band=band, mag_zero_point=27, delta_pix=delta_pix, 
-                         num_pix=num_pix)
+        coaddId_r = {"tract": my_tract, "patch": my_patch, "band": band}
+
+        # coadd cutout image
+        coadd_cut_r = butler.get(
+            "deepCoadd", parameters={"bbox": bbox}, dataId=coaddId_r
+        )
+        lens = sharp_image(
+            lens_class=lens_class,
+            band=band,
+            mag_zero_point=27,
+            delta_pix=delta_pix,
+            num_pix=num_pix,
+        )
         if flux is None:
             gsobj = galsimobj_true_flux(lens, pix_scale=delta_pix)
         else:
-            gsobj = galsim.InterpolatedImage(galsim.Image(lens), scale = delta_pix, flux = flux)
+            gsobj = galsim.InterpolatedImage(
+                galsim.Image(lens), scale=delta_pix, flux=flux
+            )
 
         wcs_r = coadd_cut_r.getWcs()
         bbox_r = coadd_cut_r.getBBox()
@@ -118,37 +122,60 @@ def lens_inejection(lens_pop, num_pix, delta_pix, butler, ra, dec, lens_cut=None
         y_center_r = (y_min_r + y_max_r) / 2
 
         center_r = geom.Point2D(x_center_r, y_center_r)
-        #geom.Point2D(26679, 15614)
+        # geom.Point2D(26679, 15614)
         point_r = wcs_r.pixelToSky(center_r)
         ra_degrees = point_r.getRa().asDegrees()
         dec_degrees = point_r.getDec().asDegrees()
         center = (ra_degrees, dec_degrees)
 
-        #image_r = butler.get("deepCoadd", parameters={'bbox':bbox_r}, dataId=coaddId_r)
+        # image_r = butler.get("deepCoadd", parameters={'bbox':bbox_r}, dataId=coaddId_r)
         arr_r = np.copy(coadd_cut_r.image.array)
 
         _add_fake_sources(coadd_cut_r, [(point_r, gsobj)])
         inj_arr_r = coadd_cut_r.image.array
         injected_final_image.append(inj_arr_r)
-        #band_report.append(band)
+        # band_report.append(band)
         box_center.append(center)
         cutout_image.append(arr_r)
-        lens_image.append((inj_arr_r-arr_r))
+        lens_image.append((inj_arr_r - arr_r))
 
-    t = Table([[lens_image[0]], [cutout_image[0]],[injected_final_image[0]], 
-               [injected_final_image[1]], [injected_final_image[2]], [box_center[0]]], 
-               names=('lens','cutout_image','injected_lens_r', 'injected_lens_g', 
-                      'injected_lens_i', 'cutout_center'))
+    t = Table(
+        [
+            [lens_image[0]],
+            [cutout_image[0]],
+            [injected_final_image[0]],
+            [injected_final_image[1]],
+            [injected_final_image[2]],
+            [box_center[0]],
+        ],
+        names=(
+            "lens",
+            "cutout_image",
+            "injected_lens_r",
+            "injected_lens_g",
+            "injected_lens_i",
+            "cutout_center",
+        ),
+    )
     return t
 
 
-def lens_inejection_fast(lens_pop, num_pix, delta_pix, butler, ra, dec, num_cutout_per_patch=10,
-                          lens_cut=None, flux=None):
+def lens_inejection_fast(
+    lens_pop,
+    num_pix,
+    delta_pix,
+    butler,
+    ra,
+    dec,
+    num_cutout_per_patch=10,
+    lens_cut=None,
+    flux=None,
+):
     """
-    Chooses a random lens from the lens population and injects it to a DC2 cutout image. For this 
-    one needs to provide a butler to this function. To initiate Butler, you need to specify data 
+    Chooses a random lens from the lens population and injects it to a DC2 cutout image. For this
+    one needs to provide a butler to this function. To initiate Butler, you need to specify data
     configuration and collection of the data.
-    
+
     :param lens_pop: lens population from sim-pipeline
     :param num_pix: number of pixel for the cutout
     :param delta_pix: pixel scale for the lens image
@@ -159,87 +186,104 @@ def lens_inejection_fast(lens_pop, num_pix, delta_pix, butler, ra, dec, num_cuto
     :param lens_cut: list of criteria for lens selection
     :param flux: flux need to be asigned to the lens image. It sould be None
     :param: path: path to save the output
-    :returns: An astropy table containing Injected lens in r-band, DC2 cutout image in r-band, 
-     cutout image with injected lens in r, g , and i band 
-    """   
-    
+    :returns: An astropy table containing Injected lens in r-band, DC2 cutout image in r-band,
+     cutout image with injected lens in r, g , and i band
+    """
+
     if lens_cut is None:
         kwargs_lens_cut = {}
     else:
         kwargs_lens_cut = lens_cut
-    
-    rgb_band_list = ['r', 'g', 'i']
+
+    rgb_band_list = ["r", "g", "i"]
     skymap = butler.get("skyMap")
     point = geom.SpherePoint(ra, dec, geom.degrees)
-    #cutoutSize = geom.ExtentI(num_pix, num_pix)
-    
+    # cutoutSize = geom.ExtentI(num_pix, num_pix)
+
     tractInfo = skymap.findTract(point)
     patchInfo = tractInfo.findPatch(point)
     my_tract = tractInfo.tract_id
     my_patch = patchInfo.getSequentialIndex()
-    
+
     coadd = []
     for band in rgb_band_list:
-        coaddId = {
-            'tract':my_tract, 
-            'patch':my_patch,
-            'band': band
-        }
-        
+        coaddId = {"tract": my_tract, "patch": my_patch, "band": band}
+
         coadd.append(butler.get("deepCoadd", dataId=coaddId))
-        
-    
+
     bbox = coadd[0].getBBox()
     xmin, ymin = bbox.getBegin()
     xmax, ymax = bbox.getEnd()
     wcs = coadd[0].getWcs()
-    
+
     x_center = np.random.randint(xmin + 150, xmax - 150, num_cutout_per_patch)
     y_center = np.random.randint(ymin + 150, ymax - 150, num_cutout_per_patch)
-    xbox_min = x_center - ((num_pix-1)/2)
-    xbox_max = x_center + ((num_pix-1)/2)
-    ybox_min = y_center - ((num_pix-1)/2)
-    ybox_max = y_center + ((num_pix-1)/2)
-    
+    xbox_min = x_center - ((num_pix - 1) / 2)
+    xbox_max = x_center + ((num_pix - 1) / 2)
+    ybox_min = y_center - ((num_pix - 1) / 2)
+    ybox_max = y_center + ((num_pix - 1) / 2)
+
     table = []
     for i in range(len(x_center)):
         lens_class = lens_pop.select_lens_at_random(**kwargs_lens_cut)
-        cutout_bbox = geom.Box2I(geom.Point2I(xbox_min[i], ybox_min[i]),geom.Point2I(xbox_max[i],
-                                                                                      ybox_max[i]))
+        cutout_bbox = geom.Box2I(
+            geom.Point2I(xbox_min[i], ybox_min[i]),
+            geom.Point2I(xbox_max[i], ybox_max[i]),
+        )
         injected_final_image = []
         box_center = []
         cutout_image_list = []
         lens_image = []
         for j in range(len(coadd)):
-            lens = sharp_image(lens_class=lens_class, band=rgb_band_list[j], mag_zero_point=27, 
-                             delta_pix=delta_pix, num_pix=num_pix)
+            lens = sharp_image(
+                lens_class=lens_class,
+                band=rgb_band_list[j],
+                mag_zero_point=27,
+                delta_pix=delta_pix,
+                num_pix=num_pix,
+            )
             cutout_image = coadd[j][cutout_bbox]
             objects = [(geom.Point2D(x_center[i], y_center[i]), lens, delta_pix)]
             final_injected_image = add_object(cutout_image, objects, calibFluxRadius=12)
-            center_wcs=wcs.pixelToSky(objects[0][0])
+            center_wcs = wcs.pixelToSky(objects[0][0])
             ra_deg = center_wcs.getRa().asDegrees()
             dec_deg = center_wcs.getDec().asDegrees()
-        
+
             injected_final_image.append(final_injected_image)
             box_center.append((ra_deg, dec_deg))
             cutout_image_list.append(cutout_image.image.array)
-            lens_image.append((final_injected_image-cutout_image.image.array))
-        table_1 = Table([[lens_image[0]], [cutout_image_list[0]],[injected_final_image[0]], 
-                         [injected_final_image[1]], [injected_final_image[2]], [box_center[0]]], 
-                         names = ('lens','cutout_image','injected_lens_r', 'injected_lens_g', 
-                                'injected_lens_i', 'cutout_center'))
+            lens_image.append((final_injected_image - cutout_image.image.array))
+        table_1 = Table(
+            [
+                [lens_image[0]],
+                [cutout_image_list[0]],
+                [injected_final_image[0]],
+                [injected_final_image[1]],
+                [injected_final_image[2]],
+                [box_center[0]],
+            ],
+            names=(
+                "lens",
+                "cutout_image",
+                "injected_lens_r",
+                "injected_lens_g",
+                "injected_lens_i",
+                "cutout_center",
+            ),
+        )
         table.append(table_1)
     lens_catalog = vstack(table)
     return lens_catalog
 
 
-def multiple_lens_injection(lens_pop, num_pix, delta_pix, butler, ra, dec, lens_cut = None, 
-                            flux = None):
+def multiple_lens_injection(
+    lens_pop, num_pix, delta_pix, butler, ra, dec, lens_cut=None, flux=None
+):
     """
-    Injects random lenses from the lens population to multiple DC2 cutout images using 
-    lens_inejection function. For this one needs to provide a butler to this function. To initiate 
+    Injects random lenses from the lens population to multiple DC2 cutout images using
+    lens_inejection function. For this one needs to provide a butler to this function. To initiate
     Butler, you need to specify data configuration and collection of the data.
-    
+
     :param lens_pop: lens population from sim-pipeline
     :param num_pix: number of pixel for the cutout
     :param delta_pix: pixel scale for the lens image
@@ -248,24 +292,43 @@ def multiple_lens_injection(lens_pop, num_pix, delta_pix, butler, ra, dec, lens_
     :param dec: dec for a cutout
     :param flux: flux need to be asigned to the lens image. It sould be None
     :param: path: path to save the output
-    :returns: An astropy table containing Injected lenses in r-band, DC2 cutout images in r-band, 
+    :returns: An astropy table containing Injected lenses in r-band, DC2 cutout images in r-band,
      cutout images with injected lens in r, g , and i band for a given set of ra and dec
     """
     injected_images = []
     for i in range(len(ra)):
-        injected_images.append(lens_inejection(lens_pop, num_pix, delta_pix, butler, ra[i], dec[i],
-                                               lens_cut=None, flux=None))
+        injected_images.append(
+            lens_inejection(
+                lens_pop,
+                num_pix,
+                delta_pix,
+                butler,
+                ra[i],
+                dec[i],
+                lens_cut=None,
+                flux=None,
+            )
+        )
     injected_image_catalog = vstack(injected_images)
     return injected_image_catalog
 
 
-def multiple_lens_injection_fast(lens_pop, num_pix, delta_pix, butler, ra, dec, 
-                                 num_cutout_per_patch=10, lens_cut = None, flux = None):
+def multiple_lens_injection_fast(
+    lens_pop,
+    num_pix,
+    delta_pix,
+    butler,
+    ra,
+    dec,
+    num_cutout_per_patch=10,
+    lens_cut=None,
+    flux=None,
+):
     """
-    Injects random lenses from the lens population to multiple DC2 cutout images using 
-    lens_inejection_fast function. For this one needs to provide a butler to this function. 
+    Injects random lenses from the lens population to multiple DC2 cutout images using
+    lens_inejection_fast function. For this one needs to provide a butler to this function.
     To initiate Butler, you need to specify data configuration and collection of the data.
-    
+
     :param lens_pop: lens population from sim-pipeline
     :param num_pix: number of pixel for the cutout
     :param delta_pix: pixel scale for the lens image
@@ -274,26 +337,36 @@ def multiple_lens_injection_fast(lens_pop, num_pix, delta_pix, butler, ra, dec,
     :param dec: dec for a cutout
     :param flux: flux need to be asigned to the lens image. It sould be None
     :param: path: path to save the output
-    :returns: An astropy table containing Injected lenses in r-band, DC2 cutout images in r-band, 
+    :returns: An astropy table containing Injected lenses in r-band, DC2 cutout images in r-band,
      cutout images with injected lens in r, g , and i band for a given set of ra and dec
     """
     injected_images = []
     for i in range(len(ra)):
-        injected_images.append(lens_inejection_fast(lens_pop, num_pix, delta_pix, butler, ra[i],
-                                                    dec[i],  num_cutout_per_patch, lens_cut=None, 
-                                                    flux=None))
+        injected_images.append(
+            lens_inejection_fast(
+                lens_pop,
+                num_pix,
+                delta_pix,
+                butler,
+                ra[i],
+                dec[i],
+                num_cutout_per_patch,
+                lens_cut=None,
+                flux=None,
+            )
+        )
     injected_image_catalog = vstack(injected_images)
     return injected_image_catalog
 
 
 def add_object(dp0_image, objects, calibFluxRadius=12):
-    """ Injects a given object in a dp0 cutout image
-    
+    """Injects a given object in a dp0 cutout image
+
     :param dp0_image: cutout image from the dp0 data or any other image
-    :param objects: a tuple of point/coordinate where we want to inject the image, source image, 
+    :param objects: a tuple of point/coordinate where we want to inject the image, source image,
      and pixel scale of source image. Eg. [(point, image, pixel_scale)]
-    :param calibFluxRadius: (optional) Aperture radius (in pixels) used to define the calibration 
-     for thisexposure+catalog. This is used to produce the correct instrumental fluxes within the 
+    :param calibFluxRadius: (optional) Aperture radius (in pixels) used to define the calibration
+     for thisexposure+catalog. This is used to produce the correct instrumental fluxes within the
      radius. The value should match that of the field defined in slot_CalibFlux_instFlux.
     :returns: an image with injected source
     """
@@ -305,20 +378,26 @@ def add_object(dp0_image, objects, calibFluxRadius=12):
     for spt, lens, pix_scale in objects:
         num_pix_lens = np.shape(lens)[0]
         if num_pix_cutout != num_pix_lens:
-            raise ValueError('Images with different pixel number cannot be combined. Please make' 
-                             'sure that your lens and dp0 cutout image have the same pixel number.'
-                             f'lens pixel number = {num_pix_lens} and dp0 image pixel number =' 
-                             f'{num_pix_cutout}')
+            raise ValueError(
+                "Images with different pixel number cannot be combined. Please make"
+                "sure that your lens and dp0 cutout image have the same pixel number."
+                f"lens pixel number = {num_pix_lens} and dp0 image pixel number ="
+                f"{num_pix_cutout}"
+            )
         if abs(pixscale - pix_scale) >= 10**-4:
-            raise ValueError('Images with different pixel scale should be combined. Please make' 
-                             'sure that your lens image and dp0 cutout image have compatible pixel' 
-                             'scale.')
+            raise ValueError(
+                "Images with different pixel scale should be combined. Please make"
+                "sure that your lens image and dp0 cutout image have compatible pixel"
+                "scale."
+            )
         else:
             pt = spt
             psfArr = psf.computeKernelImage(pt).array
             apCorr = psf.computeApertureFlux(calibFluxRadius, pt)
 
             psfArr /= apCorr
-            convolved_image = convolve2d(lens, psfArr, mode='same', boundary='symm', fillvalue=0.0)
-            injected_image =  np.array(dp0_image.image.array) + np.array(convolved_image)
-            return injected_image    
+            convolved_image = convolve2d(
+                lens, psfArr, mode="same", boundary="symm", fillvalue=0.0
+            )
+            injected_image = np.array(dp0_image.image.array) + np.array(convolved_image)
+            return injected_image

--- a/sim_pipeline/lsst_science_pipeline.py
+++ b/sim_pipeline/lsst_science_pipeline.py
@@ -16,10 +16,9 @@ the packages provided by the LSST Science Pipeline.
 
 
 def DC2_cutout(ra, dec, num_pix, butler, band):
-    """
-    Draws a cutout from the DC2 data based on the given ra, dec pair. For this one needs to provide
-    a butler to this function. To initiate Butler, you need to specify data configuration and
-    collection of the data.
+    """Draws a cutout from the DC2 data based on the given ra, dec pair. For this one
+    needs to provide a butler to this function. To initiate Butler, you need to specify
+    data configuration and collection of the data.
 
     :param ra: ra for the cutout
     :param dec: dec for the cutout
@@ -49,10 +48,9 @@ def DC2_cutout(ra, dec, num_pix, butler, band):
 def lens_inejection(
     lens_pop, num_pix, delta_pix, butler, ra, dec, lens_cut=None, flux=None
 ):
-    """
-    Chooses a random lens from the lens population and injects it to a DC2 cutout image. For this
-    one needs to provide a butler to this function. To initiate Butler, you need to specify data
-    configuration and collection of the data.
+    """Chooses a random lens from the lens population and injects it to a DC2 cutout
+    image. For this one needs to provide a butler to this function. To initiate Butler,
+    you need to specify data configuration and collection of the data.
 
     :param lens_pop: lens population from sim-pipeline
     :param num_pix: number of pixel for the cutout
@@ -63,8 +61,8 @@ def lens_inejection(
     :param lens_cut: list of criteria for lens selection
     :param flux: flux need to be asigned to the lens image. It sould be None
     :param: path: path to save the output
-    :returns: An astropy table containing Injected lens in r-band, DC2 cutout image in r-band,
-     cutout image with injected lens in r, g , and i band
+    :returns: An astropy table containing Injected lens in r-band, DC2 cutout image in
+        r-band, cutout image with injected lens in r, g , and i band
     """
     # lens = sim_lens
     if lens_cut is None:
@@ -171,10 +169,9 @@ def lens_inejection_fast(
     lens_cut=None,
     flux=None,
 ):
-    """
-    Chooses a random lens from the lens population and injects it to a DC2 cutout image. For this
-    one needs to provide a butler to this function. To initiate Butler, you need to specify data
-    configuration and collection of the data.
+    """Chooses a random lens from the lens population and injects it to a DC2 cutout
+    image. For this one needs to provide a butler to this function. To initiate Butler,
+    you need to specify data configuration and collection of the data.
 
     :param lens_pop: lens population from sim-pipeline
     :param num_pix: number of pixel for the cutout
@@ -186,8 +183,8 @@ def lens_inejection_fast(
     :param lens_cut: list of criteria for lens selection
     :param flux: flux need to be asigned to the lens image. It sould be None
     :param: path: path to save the output
-    :returns: An astropy table containing Injected lens in r-band, DC2 cutout image in r-band,
-     cutout image with injected lens in r, g , and i band
+    :returns: An astropy table containing Injected lens in r-band, DC2 cutout image in
+        r-band, cutout image with injected lens in r, g , and i band
     """
 
     if lens_cut is None:
@@ -279,10 +276,10 @@ def lens_inejection_fast(
 def multiple_lens_injection(
     lens_pop, num_pix, delta_pix, butler, ra, dec, lens_cut=None, flux=None
 ):
-    """
-    Injects random lenses from the lens population to multiple DC2 cutout images using
-    lens_inejection function. For this one needs to provide a butler to this function. To initiate
-    Butler, you need to specify data configuration and collection of the data.
+    """Injects random lenses from the lens population to multiple DC2 cutout images
+    using lens_inejection function. For this one needs to provide a butler to this
+    function. To initiate Butler, you need to specify data configuration and collection
+    of the data.
 
     :param lens_pop: lens population from sim-pipeline
     :param num_pix: number of pixel for the cutout
@@ -292,8 +289,9 @@ def multiple_lens_injection(
     :param dec: dec for a cutout
     :param flux: flux need to be asigned to the lens image. It sould be None
     :param: path: path to save the output
-    :returns: An astropy table containing Injected lenses in r-band, DC2 cutout images in r-band,
-     cutout images with injected lens in r, g , and i band for a given set of ra and dec
+    :returns: An astropy table containing Injected lenses in r-band, DC2 cutout images
+        in r-band, cutout images with injected lens in r, g , and i band for a given set
+        of ra and dec
     """
     injected_images = []
     for i in range(len(ra)):
@@ -324,10 +322,10 @@ def multiple_lens_injection_fast(
     lens_cut=None,
     flux=None,
 ):
-    """
-    Injects random lenses from the lens population to multiple DC2 cutout images using
-    lens_inejection_fast function. For this one needs to provide a butler to this function.
-    To initiate Butler, you need to specify data configuration and collection of the data.
+    """Injects random lenses from the lens population to multiple DC2 cutout images
+    using lens_inejection_fast function. For this one needs to provide a butler to this
+    function. To initiate Butler, you need to specify data configuration and collection
+    of the data.
 
     :param lens_pop: lens population from sim-pipeline
     :param num_pix: number of pixel for the cutout
@@ -337,8 +335,9 @@ def multiple_lens_injection_fast(
     :param dec: dec for a cutout
     :param flux: flux need to be asigned to the lens image. It sould be None
     :param: path: path to save the output
-    :returns: An astropy table containing Injected lenses in r-band, DC2 cutout images in r-band,
-     cutout images with injected lens in r, g , and i band for a given set of ra and dec
+    :returns: An astropy table containing Injected lenses in r-band, DC2 cutout images
+        in r-band, cutout images with injected lens in r, g , and i band for a given set
+        of ra and dec
     """
     injected_images = []
     for i in range(len(ra)):
@@ -360,14 +359,15 @@ def multiple_lens_injection_fast(
 
 
 def add_object(dp0_image, objects, calibFluxRadius=12):
-    """Injects a given object in a dp0 cutout image
+    """Injects a given object in a dp0 cutout image.
 
     :param dp0_image: cutout image from the dp0 data or any other image
-    :param objects: a tuple of point/coordinate where we want to inject the image, source image,
-     and pixel scale of source image. Eg. [(point, image, pixel_scale)]
-    :param calibFluxRadius: (optional) Aperture radius (in pixels) used to define the calibration
-     for thisexposure+catalog. This is used to produce the correct instrumental fluxes within the
-     radius. The value should match that of the field defined in slot_CalibFlux_instFlux.
+    :param objects: a tuple of point/coordinate where we want to inject the image,
+        source image, and pixel scale of source image. Eg. [(point, image, pixel_scale)]
+    :param calibFluxRadius: (optional) Aperture radius (in pixels) used to define the
+        calibration for thisexposure+catalog. This is used to produce the correct
+        instrumental fluxes within the radius. The value should match that of the field
+        defined in slot_CalibFlux_instFlux.
     :returns: an image with injected source
     """
     wcs = dp0_image.getWcs()

--- a/sim_pipeline/lsst_science_pipeline.py
+++ b/sim_pipeline/lsst_science_pipeline.py
@@ -10,8 +10,8 @@ from sim_pipeline.image_simulation import sharp_image
 from scipy.signal import convolve2d
 
 """
-This module provides necessary functions to inject lenses to the dp0 data. For this, it uses some of
-the packages provided by the LSST Science Pipeline.
+This module provides necessary functions to inject lenses to the dp0 data. For this, it 
+uses some of the packages provided by the LSST Science Pipeline.
 """
 
 
@@ -126,7 +126,7 @@ def lens_inejection(
         dec_degrees = point_r.getDec().asDegrees()
         center = (ra_degrees, dec_degrees)
 
-        # image_r = butler.get("deepCoadd", parameters={'bbox':bbox_r}, dataId=coaddId_r)
+        # image_r = butler.get("deepCoadd", parameters={'bbox':bbox_r},dataId=coaddId_r)
         arr_r = np.copy(coadd_cut_r.image.array)
 
         _add_fake_sources(coadd_cut_r, [(point_r, gsobj)])

--- a/sim_pipeline/selection.py
+++ b/sim_pipeline/selection.py
@@ -1,6 +1,5 @@
 def galaxy_cut(galaxy_list, z_min=0, z_max=5, band=None, band_max=25):
-    """
-    Selects a subset of a given galaxy list satisfying given criteria.
+    """Selects a subset of a given galaxy list satisfying given criteria.
 
     :param galaxy_list: galaxies prior to selection criteria
     :param z_min: minimum redshift of selected sample

--- a/sim_pipeline/selection.py
+++ b/sim_pipeline/selection.py
@@ -10,11 +10,12 @@ def galaxy_cut(galaxy_list, z_min=0, z_max=5, band=None, band_max=25):
     :return: subset of galaxies matching the selection criteria
     """
     if band is None:
-        bool_cut = (galaxy_list['z'] > z_min) & \
-                   (galaxy_list['z'] < z_max)
+        bool_cut = (galaxy_list["z"] > z_min) & (galaxy_list["z"] < z_max)
     else:
-        bool_cut = (galaxy_list['z'] > z_min) & \
-                   (galaxy_list['z'] < z_max) & \
-                   (galaxy_list['mag_'+band] < band_max)
+        bool_cut = (
+            (galaxy_list["z"] > z_min)
+            & (galaxy_list["z"] < z_max)
+            & (galaxy_list["mag_" + band] < band_max)
+        )
     galaxy_list_cut = galaxy_list[bool_cut]
     return galaxy_list_cut

--- a/sim_pipeline/sim_pipeline.py
+++ b/sim_pipeline/sim_pipeline.py
@@ -1,2 +1,1 @@
 """Main module."""
-

--- a/tests/test_Deflectors/test_all_lens_galaxies.py
+++ b/tests/test_Deflectors/test_all_lens_galaxies.py
@@ -1,16 +1,22 @@
 from astropy.cosmology import FlatLambdaCDM
-from sim_pipeline.Deflectors.all_lens_galaxies import AllLensGalaxies, fill_table, vel_disp_abundance_matching
+from sim_pipeline.Deflectors.all_lens_galaxies import (
+    AllLensGalaxies,
+    fill_table,
+    vel_disp_abundance_matching,
+)
 from sim_pipeline.Pipelines.skypy_pipeline import SkyPyPipeline
 from astropy.units import Quantity
 from astropy.table import Table
 import numpy as np
 import pytest
 
-def galaxy_list(): 
-    sky_area = Quantity(value=0.1, unit='deg2')
+
+def galaxy_list():
+    sky_area = Quantity(value=0.1, unit="deg2")
     pipeline = SkyPyPipeline(skypy_config=None, sky_area=sky_area, filters=None)
     return pipeline.red_galaxies, pipeline.blue_galaxies
-    
+
+
 @pytest.fixture
 def all_lens_galaxies():
     red_galaxies = galaxy_list()[0]
@@ -18,34 +24,45 @@ def all_lens_galaxies():
     kwargs_deflector_cut = {}
     kwargs_mass2light = {}
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-    sky_area = Quantity(value=0.1, unit='deg2')
-    return AllLensGalaxies(red_galaxies, blue_galaxies,
-                                            kwargs_cut=kwargs_deflector_cut, kwargs_mass2light=kwargs_mass2light,
-                                            cosmo = cosmo, sky_area = sky_area)
+    sky_area = Quantity(value=0.1, unit="deg2")
+    return AllLensGalaxies(
+        red_galaxies,
+        blue_galaxies,
+        kwargs_cut=kwargs_deflector_cut,
+        kwargs_mass2light=kwargs_mass2light,
+        cosmo=cosmo,
+        sky_area=sky_area,
+    )
+
 
 def test_deflector_number_draw_deflector(all_lens_galaxies):
     galaxy_pop = all_lens_galaxies
     num_deflectors = galaxy_pop.deflector_number()
     deflector = galaxy_pop.draw_deflector()
-    assert deflector['z'] != 0
+    assert deflector["z"] != 0
     assert num_deflectors >= 0
+
 
 def test_fill_table():
     mock_galaxy_list = galaxy_list()[0]
     filled_table = fill_table(mock_galaxy_list)
     assert isinstance(filled_table, Table)
 
+
 def test_vel_disp_abundance_matching():
     mock_galaxy_list = galaxy_list()[0]
-    sky_area = Quantity(value=0.1, unit='deg2')
+    sky_area = Quantity(value=0.1, unit="deg2")
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
 
-    f_vel_disp = vel_disp_abundance_matching(mock_galaxy_list, z_max=0.5, sky_area=sky_area, cosmo=cosmo)
+    f_vel_disp = vel_disp_abundance_matching(
+        mock_galaxy_list, z_max=0.5, sky_area=sky_area, cosmo=cosmo
+    )
 
     assert callable(f_vel_disp)
     stellar_mass = 10 ** np.random.uniform(9, 12, 10)
     vel_disp = f_vel_disp(np.log10(stellar_mass))
     assert isinstance(vel_disp, np.ndarray)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     pytest.main()

--- a/tests/test_Deflectors/test_velocity_dispersion.py
+++ b/tests/test_Deflectors/test_velocity_dispersion.py
@@ -1,36 +1,51 @@
-
-from sim_pipeline.Deflectors.velocity_dispersion import schechter_vel_disp, schechter_velocity_dispersion_function
+from sim_pipeline.Deflectors.velocity_dispersion import (
+    schechter_vel_disp,
+    schechter_velocity_dispersion_function,
+)
 import numpy as np
 
 
 def test_schechter_vdf():
-
     # SDSS velocity dispersion function for galaxies brighter than Mr >= -16.8
     from astropy.cosmology import FlatLambdaCDM
+
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
 
-    phi_star = 8.0 * 10 ** (-3) / cosmo.h ** 3
+    phi_star = 8.0 * 10 ** (-3) / cosmo.h**3
     vd_star = 161
     alpha = 2.32
     beta = 2.67
 
-    vel_disp_list = schechter_velocity_dispersion_function(alpha, beta, vd_star, vd_min=50, vd_max=500, size=10000, 
-                                  resolution=100)
+    vel_disp_list = schechter_velocity_dispersion_function(
+        alpha, beta, vd_star, vd_min=50, vd_max=500, size=10000, resolution=100
+    )
 
-    #plt.hist(np.log10(vel_disp_list))
-    #plt.show()
+    # plt.hist(np.log10(vel_disp_list))
+    # plt.show()
 
     redshift = np.linspace(start=0, stop=0.2, num=10)
     from astropy.units import Quantity
-    sky_area = Quantity(value=0.1, unit='deg2')
+
+    sky_area = Quantity(value=0.1, unit="deg2")
     vd_min, vd_max = 50, 500
     from astropy.cosmology import FlatLambdaCDM
+
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
     cosmology = cosmo
     np.random.seed(42)
 
-    z_list, vel_disp_list = schechter_vel_disp(redshift, phi_star, alpha, beta, vd_star, vd_min,
-                                                vd_max, sky_area, cosmology, noise=True)
+    z_list, vel_disp_list = schechter_vel_disp(
+        redshift,
+        phi_star,
+        alpha,
+        beta,
+        vd_star,
+        vd_min,
+        vd_max,
+        sky_area,
+        cosmology,
+        noise=True,
+    )
     assert len(z_list) == 373
 
     # plt.hist(np.log10(vel_disp_list))

--- a/tests/test_Observations/test_roman_speclite.py
+++ b/tests/test_Observations/test_roman_speclite.py
@@ -1,7 +1,10 @@
 import speclite.filters
 import os
 import sim_pipeline
-from sim_pipeline.Observations.roman_speclite import configure_roman_filters, filter_names
+from sim_pipeline.Observations.roman_speclite import (
+    configure_roman_filters,
+    filter_names,
+)
 
 
 def test_roman_speclite():
@@ -10,16 +13,18 @@ def test_roman_speclite():
     path = os.path.dirname(sim_pipeline.__file__)
     module_path, _ = os.path.split(path)
 
-    save_path = os.path.join(module_path, 'data/Filters/Roman/')
+    save_path = os.path.join(module_path, "data/Filters/Roman/")
 
     filter_name_list = filter_names()
-    #print(filter_name_list[0], 'test filter_name_list')
+    # print(filter_name_list[0], 'test filter_name_list')
     speclite.filters.load_filters(filter_name_list[0], filter_name_list[1])
-    speclite.filters.load_filters(save_path + 'Roman-F062.ecsv',
-                                  save_path + 'Roman-F087.ecsv',
-                                  save_path + 'Roman-F106.ecsv')
+    speclite.filters.load_filters(
+        save_path + "Roman-F062.ecsv",
+        save_path + "Roman-F087.ecsv",
+        save_path + "Roman-F106.ecsv",
+    )
 
-    speclite.filters.load_filters('Roman-F062', 'Roman-F087', 'Roman-F106')
-    #os.remove(save_path + 'Roman-F062.ecsv')
-    #os.remove(save_path + 'Roman-F087.ecsv')
-    #os.remove(save_path + 'Roman-F106.ecsv')
+    speclite.filters.load_filters("Roman-F062", "Roman-F087", "Roman-F106")
+    # os.remove(save_path + 'Roman-F062.ecsv')
+    # os.remove(save_path + 'Roman-F087.ecsv')
+    # os.remove(save_path + 'Roman-F106.ecsv')

--- a/tests/test_Pipelines/test_skypy_pipeline.py
+++ b/tests/test_Pipelines/test_skypy_pipeline.py
@@ -2,16 +2,16 @@ from sim_pipeline.Pipelines.skypy_pipeline import SkyPyPipeline
 
 
 class TestSkyPyPipeline(object):
-
     def setup_method(self):
         from astropy.units import Quantity
-        sky_area = Quantity(value=0.05, unit='deg2')
+
+        sky_area = Quantity(value=0.05, unit="deg2")
         self.pipeline = SkyPyPipeline(skypy_config=None, sky_area=sky_area)
 
     def test_blue_galaxies(self):
         blue_galaxies = self.pipeline.blue_galaxies
-        assert blue_galaxies[0]['z'] > 0
+        assert blue_galaxies[0]["z"] > 0
 
     def test_red_galaxies(self):
         red_galaxies = self.pipeline.red_galaxies
-        assert red_galaxies[0]['z'] > 0
+        assert red_galaxies[0]["z"] > 0

--- a/tests/test_Plots/test_galaxy_galaxy_plots.py
+++ b/tests/test_Plots/test_galaxy_galaxy_plots.py
@@ -6,41 +6,54 @@ from astropy.units import Quantity
 from sim_pipeline.Plots.galaxy_galaxy_plots import GalaxyGalaxyLensingPlots
 import matplotlib.pyplot as plt
 
+
 def gg_lens_pop_instance():
-        cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-        sky_area = Quantity(value=0.1, unit='deg2')
-        return GalaxyGalaxyLensPop(sky_area=sky_area, cosmo=cosmo)
+    cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+    sky_area = Quantity(value=0.1, unit="deg2")
+    return GalaxyGalaxyLensPop(sky_area=sky_area, cosmo=cosmo)
+
 
 @pytest.fixture
 def galaxy_galaxy_lensing_plots():
     lens_pop = gg_lens_pop_instance()
     return GalaxyGalaxyLensingPlots(lens_pop, num_pix=64, coadd_years=10)
 
+
 def test_rgb_image(galaxy_galaxy_lensing_plots):
     lens_pop = gg_lens_pop_instance()
     kwargs_lens_cut = {}
     lens_class = lens_pop.select_lens_at_random(**kwargs_lens_cut)
-    rgb_band_list = ['r', 'g', 'i']
+    rgb_band_list = ["r", "g", "i"]
     add_noise = True
-    image_rgb = galaxy_galaxy_lensing_plots.rgb_image(lens_class, rgb_band_list, add_noise=add_noise)
+    image_rgb = galaxy_galaxy_lensing_plots.rgb_image(
+        lens_class, rgb_band_list, add_noise=add_noise
+    )
 
     assert isinstance(image_rgb, np.ndarray)
-    assert image_rgb.shape == (galaxy_galaxy_lensing_plots.num_pix, galaxy_galaxy_lensing_plots.num_pix, 3)
+    assert image_rgb.shape == (
+        galaxy_galaxy_lensing_plots.num_pix,
+        galaxy_galaxy_lensing_plots.num_pix,
+        3,
+    )
+
 
 def test_plot_montage(galaxy_galaxy_lensing_plots):
-    rgb_band_list = ['r', 'g', 'i']
+    rgb_band_list = ["r", "g", "i"]
     add_noise = True
     n_horizont = 2
     n_vertical = 2
     kwargs_lens_cut_plot = None
-    fig, axes = galaxy_galaxy_lensing_plots.plot_montage(rgb_band_list, add_noise=add_noise, 
-                    n_horizont=n_horizont, n_vertical=n_vertical, kwargs_lens_cut=kwargs_lens_cut_plot)
+    fig, axes = galaxy_galaxy_lensing_plots.plot_montage(
+        rgb_band_list,
+        add_noise=add_noise,
+        n_horizont=n_horizont,
+        n_vertical=n_vertical,
+        kwargs_lens_cut=kwargs_lens_cut_plot,
+    )
     assert isinstance(fig, plt.Figure)
     assert len(axes) == n_vertical
     assert len(axes[0]) == n_horizont
 
+
 if __name__ == "__main__":
     pytest.main()
-         
-
-    

--- a/tests/test_Source/test_galaxies.py
+++ b/tests/test_Source/test_galaxies.py
@@ -5,28 +5,34 @@ from sim_pipeline.Sources.galaxies import Galaxies
 from sim_pipeline.Sources.galaxies import galaxy_projected_eccentricity
 import pytest
 
+
 class test_galaxies(object):
-        def setup_method(self): 
-            sky_area = Quantity(value=0.1, unit='deg2')
-            pipeline = SkyPyPipeline(skypy_config=None, sky_area=sky_area, filters=None)
-            self.galaxy_list = pipeline.red_galaxies
-            self.cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-            self.galaxies = Galaxies(galaxy_list = self.galaxy_list, kwargs_cut = None, 
-                                     cosmo = self.cosmo, sky_area = sky_area)
+    def setup_method(self):
+        sky_area = Quantity(value=0.1, unit="deg2")
+        pipeline = SkyPyPipeline(skypy_config=None, sky_area=sky_area, filters=None)
+        self.galaxy_list = pipeline.red_galaxies
+        self.cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+        self.galaxies = Galaxies(
+            galaxy_list=self.galaxy_list,
+            kwargs_cut=None,
+            cosmo=self.cosmo,
+            sky_area=sky_area,
+        )
 
-            
-        def test_source_number(self):
-            number = self.galaxies.source_number()
-            assert number > 0
+    def test_source_number(self):
+        number = self.galaxies.source_number()
+        assert number > 0
 
-        def test_draw_source(self):
-             galaxy = self.galaxies.draw_source()
-             assert len(galaxy) > 0
+    def test_draw_source(self):
+        galaxy = self.galaxies.draw_source()
+        assert len(galaxy) > 0
+
 
 def test_galaxy_projected_eccentricity():
-     e1, e2 = galaxy_projected_eccentricity(0)
-     assert e1 == 0
-     assert e2 == 0
+    e1, e2 = galaxy_projected_eccentricity(0)
+    assert e1 == 0
+    assert e2 == 0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     pytest.main()

--- a/tests/test_galaxy_galaxy_lens.py
+++ b/tests/test_galaxy_galaxy_lens.py
@@ -1,8 +1,11 @@
 import pytest
 from astropy.cosmology import FlatLambdaCDM
 from astropy.table import Table
-from sim_pipeline.galaxy_galaxy_lens import (GalaxyGalaxyLens, image_separation_from_positions,
-                                              theta_e_when_source_infinity)
+from sim_pipeline.galaxy_galaxy_lens import (
+    GalaxyGalaxyLens,
+    image_separation_from_positions,
+    theta_e_when_source_infinity,
+)
 
 import os
 
@@ -15,13 +18,21 @@ class TestGalaxyGalaxyLens(object):
         path = os.path.dirname(__file__)
         module_path, _ = os.path.split(path)
         print(path, module_path)
-        blue_one = Table.read(os.path.join(path, 'TestData/blue_one_modified.fits'), format='fits')
-        red_one = Table.read(os.path.join(path, 'TestData/red_one_modified.fits'), format='fits')
+        blue_one = Table.read(
+            os.path.join(path, "TestData/blue_one_modified.fits"), format="fits"
+        )
+        red_one = Table.read(
+            os.path.join(path, "TestData/red_one_modified.fits"), format="fits"
+        )
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
         self.source_dict = blue_one
         self.deflector_dict = red_one
         while True:
-            gg_lens = GalaxyGalaxyLens(source_dict=self.source_dict, deflector_dict=self.deflector_dict, cosmo=cosmo)
+            gg_lens = GalaxyGalaxyLens(
+                source_dict=self.source_dict,
+                deflector_dict=self.deflector_dict,
+                cosmo=cosmo,
+            )
             if gg_lens.validity_test():
                 self.gg_lens = gg_lens
                 break
@@ -34,24 +45,28 @@ class TestGalaxyGalaxyLens(object):
         assert pytest.approx(e2_mass, rel=1e-3) == 0.09710653297997263
 
     def test_deflector_magnitude(self):
-        band = 'g'
+        band = "g"
         deflector_magnitude = self.gg_lens.deflector_magnitude(band)
         assert isinstance(deflector_magnitude[0], float)
         assert pytest.approx(deflector_magnitude[0], rel=1e-3) == 26.4515655
 
     def test_source_magnitude(self):
-        band = 'g'
+        band = "g"
         source_magnitude = self.gg_lens.extended_source_magnitude(band)
         assert pytest.approx(source_magnitude[0], rel=1e-3) == 30.780194
 
     def test_image_separation_from_positions(self):
         image_positions = self.gg_lens.image_positions()
         image_separation = image_separation_from_positions(image_positions)
-        theta_E_infinity = theta_e_when_source_infinity(deflector_dict=self.deflector_dict)
+        theta_E_infinity = theta_e_when_source_infinity(
+            deflector_dict=self.deflector_dict
+        )
         assert image_separation < 2 * theta_E_infinity
 
     def test_theta_e_when_source_infinity(self):
-        theta_E_infinity = theta_e_when_source_infinity(deflector_dict=self.deflector_dict)
+        theta_E_infinity = theta_e_when_source_infinity(
+            deflector_dict=self.deflector_dict
+        )
         # We expect that theta_E_infinity should be less than 15
         assert theta_E_infinity < 15
 
@@ -72,5 +87,5 @@ class TestGalaxyGalaxyLens(object):
         assert losd != 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/tests/test_galaxy_galaxy_lens_pop.py
+++ b/tests/test_galaxy_galaxy_lens_pop.py
@@ -8,32 +8,42 @@ import numpy as np
 @pytest.fixture
 def gg_lens_pop_instance():
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-    sky_area = Quantity(value=0.1, unit='deg2')
+    sky_area = Quantity(value=0.1, unit="deg2")
     return GalaxyGalaxyLensPop(sky_area=sky_area, cosmo=cosmo)
+
 
 def test_num_lenses_and_sources(gg_lens_pop_instance):
     num_lenses = gg_lens_pop_instance.deflector_number()
     num_sources = gg_lens_pop_instance.source_number()
 
-    assert 100 <= num_lenses <= 6600, "Expected num_lenses to be between 5800 and 6600," 
+    assert 100 <= num_lenses <= 6600, "Expected num_lenses to be between 5800 and 6600,"
     f"but got {num_lenses}"
-    assert 100000 <= num_sources <= 500000, "Expected num_sources to be between 1090000 and" 
+    assert (
+        100000 <= num_sources <= 500000
+    ), "Expected num_sources to be between 1090000 and"
     f"1110000, but got {num_sources}"
     # assert 1 == 0
+
 
 def test_num_sources_tested_and_test_area(gg_lens_pop_instance):
     lens = gg_lens_pop_instance._lens_galaxies.draw_deflector()
     test_area = draw_test_area(deflector=lens)
-    assert 0.01 < test_area < 100 * np.pi, "Expected test_area to be between 0.1 and 100*pi,"
+    assert (
+        0.01 < test_area < 100 * np.pi
+    ), "Expected test_area to be between 0.1 and 100*pi,"
     f"but got {test_area}"
     num_sources_range = gg_lens_pop_instance.get_num_sources_tested(testarea=test_area)
-    assert 0 <= num_sources_range <= 50, "Expected num_sources_range to be between 0 and 50,"
+    assert (
+        0 <= num_sources_range <= 50
+    ), "Expected num_sources_range to be between 0 and 50,"
     f"but got {num_sources_range}"
+
 
 def test_draw_population(gg_lens_pop_instance):
     kwargs_lens_cuts = {}
     gg_lens_population = gg_lens_pop_instance.draw_population(kwargs_lens_cuts)
     assert isinstance(gg_lens_population, list)
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_gaussian_mixture_model.py
+++ b/tests/test_gaussian_mixture_model.py
@@ -1,6 +1,7 @@
 import numpy as np
 from sim_pipeline.ParamDistributions.gaussian_mixture_model import GaussianMixtureModel
 
+
 def test_gaussian_mixture_model():
     model = GaussianMixtureModel()
     means = [0.00330796, -0.07635054, 0.11829008]
@@ -9,7 +10,9 @@ def test_gaussian_mixture_model():
 
     # Check if model was initialized correctly
     assert model.means == means, "Model means do not match expected means."
-    assert model.stds == stds,"Model standard deviations do not match expected standard deviations."
+    assert (
+        model.stds == stds
+    ), "Model standard deviations do not match expected standard deviations."
     assert model.weights == weights, "Model weights do not match expected weights."
 
     # Check if `rvs` function returns an array of the correct size
@@ -19,5 +22,7 @@ def test_gaussian_mixture_model():
 
     # Check if at least 80% of the samples are between -1 and 1
     within_range = np.sum((-1 <= samples) & (samples <= 1))
-    assert within_range / size >= 0.8, "Less than 80% of samples are within the range (-1, 1)." 
+    assert (
+        within_range / size >= 0.8
+    ), "Less than 80% of samples are within the range (-1, 1)."
     f"Only {within_range / size * 100}% are within range."

--- a/tests/test_image_simulation.py
+++ b/tests/test_image_simulation.py
@@ -2,62 +2,122 @@ import os
 from astropy.table import Table
 from astropy.cosmology import FlatLambdaCDM
 from sim_pipeline.galaxy_galaxy_lens import GalaxyGalaxyLens
-from sim_pipeline.image_simulation import (simulate_image, sharp_image, galsimobj, 
-                                        galsimobj_true_flux, sharp_rgb_image, rgb_image_from_image_list)
+from sim_pipeline.image_simulation import (
+    simulate_image,
+    sharp_image,
+    galsimobj,
+    galsimobj_true_flux,
+    sharp_rgb_image,
+    rgb_image_from_image_list,
+)
 
 
 class TestImageSimulation(object):
-
     def setup_method(self):
         # path = os.path.dirname(sim_pipeline.__file__)
 
         path = os.path.dirname(__file__)
         module_path, _ = os.path.split(path)
         print(path, module_path)
-        blue_one = Table.read(os.path.join(path, 'TestData/blue_one_modified.fits'), format='fits')
-        red_one = Table.read(os.path.join(path, 'TestData/red_one_modified.fits'), format='fits')
+        blue_one = Table.read(
+            os.path.join(path, "TestData/blue_one_modified.fits"), format="fits"
+        )
+        red_one = Table.read(
+            os.path.join(path, "TestData/red_one_modified.fits"), format="fits"
+        )
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
         self.source_dict = blue_one
         self.deflector_dict = red_one
         while True:
-            gg_lens = GalaxyGalaxyLens(source_dict=self.source_dict, deflector_dict=self.deflector_dict, cosmo=cosmo)
+            gg_lens = GalaxyGalaxyLens(
+                source_dict=self.source_dict,
+                deflector_dict=self.deflector_dict,
+                cosmo=cosmo,
+            )
             if gg_lens.validity_test():
                 self.gg_lens = gg_lens
                 break
 
     def test_simulate_image(self):
-        image = simulate_image(lens_class=self.gg_lens, band='g', num_pix=100, add_noise=True, observatory='LSST')
+        image = simulate_image(
+            lens_class=self.gg_lens,
+            band="g",
+            num_pix=100,
+            add_noise=True,
+            observatory="LSST",
+        )
         assert len(image) == 100
 
     def test_sharp_image(self):
-        image = sharp_image(lens_class=self.gg_lens, band='g', mag_zero_point=30, delta_pix=0.05, num_pix=100,
-                            with_deflector=True)
+        image = sharp_image(
+            lens_class=self.gg_lens,
+            band="g",
+            mag_zero_point=30,
+            delta_pix=0.05,
+            num_pix=100,
+            with_deflector=True,
+        )
         assert len(image) == 100
 
     def test_galsimobj(self):
-        image = sharp_image(lens_class=self.gg_lens, band='g', mag_zero_point=30, delta_pix=0.05, num_pix=100,
-                            with_deflector=True)
+        image = sharp_image(
+            lens_class=self.gg_lens,
+            band="g",
+            mag_zero_point=30,
+            delta_pix=0.05,
+            num_pix=100,
+            with_deflector=True,
+        )
         gsobj = galsimobj(image, 0.2, 10000)
         assert len(gsobj.image.array) == 100
 
     def test_galsimobj_true_flux(self):
-        image = sharp_image(lens_class=self.gg_lens, band='g', mag_zero_point=30, delta_pix=0.05, num_pix=100,
-                            with_deflector=True)
+        image = sharp_image(
+            lens_class=self.gg_lens,
+            band="g",
+            mag_zero_point=30,
+            delta_pix=0.05,
+            num_pix=100,
+            with_deflector=True,
+        )
         gsobj = galsimobj_true_flux(image, 0.2)
         assert len(gsobj.image.array) == 100
 
     def test_sharp_rgb_image(self):
-        image = sharp_rgb_image(lens_class = self.gg_lens, rgb_band_list = ['r', 'g', 'i'], mag_zero_point = 30,
-                                 delta_pix = 0.05, num_pix = 100)
+        image = sharp_rgb_image(
+            lens_class=self.gg_lens,
+            rgb_band_list=["r", "g", "i"],
+            mag_zero_point=30,
+            delta_pix=0.05,
+            num_pix=100,
+        )
         assert len(image) == 100
 
     def test_rgb_image_from_image_list(self):
-        image_g = sharp_image(lens_class=self.gg_lens, band='g', mag_zero_point=30, delta_pix=0.05, num_pix=100,
-                            with_deflector=True)
-        image_r = sharp_image(lens_class=self.gg_lens, band='r', mag_zero_point=30, delta_pix=0.05, num_pix=100,
-                            with_deflector=True)
-        image_b = sharp_image(lens_class=self.gg_lens, band='i', mag_zero_point=30, delta_pix=0.05, num_pix=100,
-                            with_deflector=True)
+        image_g = sharp_image(
+            lens_class=self.gg_lens,
+            band="g",
+            mag_zero_point=30,
+            delta_pix=0.05,
+            num_pix=100,
+            with_deflector=True,
+        )
+        image_r = sharp_image(
+            lens_class=self.gg_lens,
+            band="r",
+            mag_zero_point=30,
+            delta_pix=0.05,
+            num_pix=100,
+            with_deflector=True,
+        )
+        image_b = sharp_image(
+            lens_class=self.gg_lens,
+            band="i",
+            mag_zero_point=30,
+            delta_pix=0.05,
+            num_pix=100,
+            with_deflector=True,
+        )
         image_list = [image_r, image_g, image_b]
         image = rgb_image_from_image_list(image_list, 0.5)
         assert len(image) == 100

--- a/tests/test_param_util.py
+++ b/tests/test_param_util.py
@@ -1,13 +1,16 @@
 from sim_pipeline.Util.param_util import epsilon2e, e2epsilon, random_ra_dec
 
+
 def test_epsilon2e():
-    e= epsilon2e(0)
+    e = epsilon2e(0)
     assert e == 0
+
 
 def test_e2epsilon():
     ep = e2epsilon(0)
     assert ep == 0
 
+
 def test_random_ra_dec():
-    ra, dec = random_ra_dec(ra_min = 30, ra_max = 62, dec_min = -63, dec_max = -36, n=50)
+    ra, dec = random_ra_dec(ra_min=30, ra_max=62, dec_min=-63, dec_max=-36, n=50)
     assert len(ra) == 50


### PR DESCRIPTION
This PR has autoformatting of all the codes and docstrings with these commands:

```
black .
docformatter -r ./* --black --in-place
```

Auto-formatting of all future commits is also added using the pre-commit CI. 

The line-length limit in *.py files is set to 88 characters. In notebooks, it is still 120 characters.

Merging this PR will close #40.