### PR TITLE
include a magnification limit to remove highly de-magnified images

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,45 @@
-name: Pre-commit QA
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
 
-on:
-  pull_request:
-  push:
-    branches: [main]
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false
 
-jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.0.279
+    hooks:
+      - id: ruff
+        exclude: docs/.*
+        args: ["--line-length=88"]
+  - repo: https://github.com/nbQA-dev/nbQA
+    rev: 1.7.0
+    hooks:
+      - id: nbqa-ruff
+        args: ["--line-length=120"]
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black-jupyter
+        language_version: python3
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.5
+    hooks:
+      - id: docformatter
+        additional_dependencies: [tomli]
+        args: [-r, --black, --in-place]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -29,6 +29,17 @@ Finally add the ``sim-pipeline-project`` repository as a *remote*. This will all
   git remote add sim-pipeline-project https://github.com/LSST-strong-lensing/sim-pipeline.git
 
 
+Install sim-pipeline in development mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To run your own version of sim-pipeline and making sure that your own development changes are reflected (as well as switcing branches),
+install the sim-pipeline package in development mode with
+
+::
+
+  cd sim-pipeline
+  python setup.py develop --user
+
+
 Create a branch for your new feature
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/sim_pipeline/galaxy_galaxy_lens.py
+++ b/sim_pipeline/galaxy_galaxy_lens.py
@@ -21,7 +21,7 @@ class GalaxyGalaxyLens(object):
         mixgauss_means=None,
         mixgauss_stds=None,
         mixgauss_weights=None,
-        magnification_limit=0.1,
+        magnification_limit=0.01,
     ):
         """
 

--- a/sim_pipeline/galaxy_galaxy_lens.py
+++ b/sim_pipeline/galaxy_galaxy_lens.py
@@ -21,7 +21,7 @@ class GalaxyGalaxyLens(object):
         mixgauss_means=None,
         mixgauss_stds=None,
         mixgauss_weights=None,
-        magnification_limit=0.01,
+        magnification_limit=0.01
     ):
         """
 
@@ -178,7 +178,9 @@ class GalaxyGalaxyLens(object):
         # Criteria 6: (optional)
         # compute the magnified brightness of the lensed extended arc for different
         # bands at least in one band, the magnitude has to be brighter than the limit
-        if mag_arc_limit is not None:
+        if mag_arc_limit is not None and self._source_type in ['extended']:
+            # makes sure magnification of extended source is only used when there is
+            # an extended source
             bool_mag_limit = False
             host_mag = self.host_magnification()
             for band, mag_limit_band in mag_arc_limit.items():

--- a/sim_pipeline/galaxy_galaxy_lens.py
+++ b/sim_pipeline/galaxy_galaxy_lens.py
@@ -21,6 +21,7 @@ class GalaxyGalaxyLens(object):
         mixgauss_means=None,
         mixgauss_stds=None,
         mixgauss_weights=None,
+        magnification_limit=0.1,
     ):
         """
 
@@ -39,6 +40,9 @@ class GalaxyGalaxyLens(object):
         :type mixgauss_weights: list of float
         :type mixgauss_stds: list of float
         :type mixgauss_means: list of float
+        :param magnification_limit: absolute lensing magnification lower limit to
+            register a point source (ignore highly de-magnified images)
+        :type magnification_limit: float >= 0
         """
         self._source_dict = source_dict
         self._lens_dict = deflector_dict
@@ -48,6 +52,7 @@ class GalaxyGalaxyLens(object):
         self._mixgauss_means = mixgauss_means
         self._mixgauss_stds = mixgauss_stds
         self._mixgauss_weights = mixgauss_weights
+        self._magnification_limit = magnification_limit
         if self._lens_dict["z"] >= self._source_dict["z"]:
             self._theta_E_sis = 0
         else:
@@ -97,8 +102,8 @@ class GalaxyGalaxyLens(object):
 
     def image_positions(self):
         """Return image positions by solving the lens equation. These are either the
-        centers of the extended source, or the point sources in case of (added) point-
-        like sources, such as quasars or SNe.
+        centers of the extended source, or the point sources in case of (added)
+        point-like sources, such as quasars or SNe.
 
         :return: x-pos, y-pos
         """
@@ -119,6 +124,7 @@ class GalaxyGalaxyLens(object):
                 solver="lenstronomy",
                 search_window=self.einstein_radius * 6,
                 min_distance=self.einstein_radius * 6 / 100,
+                magnification_limit=self._magnification_limit
             )
         return self._image_positions
 


### PR DESCRIPTION
This PR adds the option to not include highly de-magnified images in the image position catalogue. While this most likely does not change any appearances in the simulation of images, it can affect the image catalogue and reflects more closely observable images.